### PR TITLE
fix: default prefix search to exact match (issue #9) and add Docker CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,65 @@
+name: Docker
+
+on:
+  push:
+    # On merge/push to main → tag as bgpkit/wayback-rpki:main
+    branches:
+      - main
+    paths:
+      - "Dockerfile"
+      - "src/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/docker.yml"
+    # On new version tag → tag as bgpkit/wayback-rpki:{version} and bgpkit/wayback-rpki:latest
+    tags:
+      - v[0-9]+.*
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: bgpkit/wayback-rpki
+          # On branch push to main: type=ref,event=branch → "main"
+          # On tag push v1.3.0: type=semver → "1.3.0", "1.3", and "latest"
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # QEMU enables building for non-native architectures (e.g. arm64 on
+      # amd64 runners) via emulation. Slower than native runners but works
+      # for a single-job workflow without splitting into a platform matrix.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,13 +5,9 @@ on:
     # On merge/push to main → tag as bgpkit/wayback-rpki:main
     branches:
       - main
-    paths:
-      - "Dockerfile"
-      - "src/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - ".github/workflows/docker.yml"
     # On new version tag → tag as bgpkit/wayback-rpki:{version} and bgpkit/wayback-rpki:latest
+    # NOTE: no `paths` filter — tag pushes must always trigger so release images
+    # are never silently skipped (the release.yml workflow runs in parallel).
     tags:
       - v[0-9]+.*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # select build image
-FROM rust:1.85 as build
+FROM rust:1.90 AS build
 
 # create a new empty shell project
 RUN USER=root cargo new --bin my_project
@@ -8,6 +8,7 @@ WORKDIR /my_project
 # copy your source tree
 COPY ./src ./src
 COPY ./Cargo.toml .
+COPY ./Cargo.lock .
 
 # build for release
 RUN cargo build --release

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,6 +1,6 @@
 use crate::RoasTrie;
 use axum::extract::{Query, State};
-use axum::http::Method;
+use axum::http::{Method, StatusCode};
 use axum::response::IntoResponse;
 use axum::routing::get;
 use axum::{Json, Router};
@@ -87,6 +87,31 @@ async fn search(
         page_size = 1000;
     }
 
+    // Parse prefix and date early so we can return a clean 400 instead of
+    // panicking (→ 500) on malformed input.
+    let prefix = match query.prefix.as_ref().map(|p| p.parse()) {
+        Some(Ok(p)) => Some(p),
+        Some(Err(_)) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "invalid prefix"})),
+            )
+                .into_response();
+        }
+        None => None,
+    };
+    let date = match query.date.as_ref().map(|d| d.parse()) {
+        Some(Ok(d)) => Some(d),
+        Some(Err(_)) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "invalid date"})),
+            )
+                .into_response();
+        }
+        None => None,
+    };
+
     let trie = state.read().await;
     let latest_ts = trie.latest_date;
     let latest_date = DateTime::from_timestamp(latest_ts, 0)
@@ -94,10 +119,10 @@ async fn search(
         .naive_utc()
         .date();
     let mut results = trie.search(
-        query.prefix.clone().map(|p| p.parse().unwrap()),
+        prefix,
         query.asn,
         query.max_len,
-        query.date.clone().map(|d| d.parse().unwrap()),
+        date,
         query.current,
         query.exact.unwrap_or(true),
     );

--- a/src/api.rs
+++ b/src/api.rs
@@ -126,7 +126,7 @@ async fn search(
         query.current,
         query.exact.unwrap_or(true),
     );
-    results.sort_by(|a, b| a.prefix.cmp(&b.prefix));
+    results.sort_by_key(|a| a.prefix);
     let result_entries = results
         .iter()
         .map(|entry| RoasSearchResultEntry {

--- a/src/api.rs
+++ b/src/api.rs
@@ -35,6 +35,9 @@ pub struct RoasSearchQuery {
 
     /// number of items per page, maximum 1000
     page_size: Option<usize>,
+
+    /// if true (default), only return exact prefix matches; if false, include supernets and subnets
+    exact: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -96,6 +99,7 @@ async fn search(
         query.max_len,
         query.date.clone().map(|d| d.parse().unwrap()),
         query.current,
+        query.exact.unwrap_or(true),
     );
     results.sort_by(|a, b| a.prefix.cmp(&b.prefix));
     let result_entries = results

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -220,7 +220,7 @@ fn main() {
             check_bootstrap_and_download(path.as_str(), opts.bootstrap);
             let trie = RoasTrie::load(path.as_str()).unwrap();
             let results: Vec<RoasLookupEntryTabled> = trie
-                .search(prefix, asn, max_len, date, current)
+                .search(prefix, asn, max_len, date, current, true)
                 .into_iter()
                 .map(|entry| entry.into())
                 .collect();

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -86,6 +86,10 @@ enum Opts {
         /// filter results to whether ROA is still current
         #[clap(short, long)]
         current: Option<bool>,
+
+        /// only return exact prefix matches (default: true); set to false to include supernets and subnets
+        #[clap(short, long)]
+        exact: Option<bool>,
     },
     /// Serve the API
     Serve {
@@ -216,11 +220,12 @@ fn main() {
             max_len,
             date,
             current,
+            exact,
         } => {
             check_bootstrap_and_download(path.as_str(), opts.bootstrap);
             let trie = RoasTrie::load(path.as_str()).unwrap();
             let results: Vec<RoasLookupEntryTabled> = trie
-                .search(prefix, asn, max_len, date, current, true)
+                .search(prefix, asn, max_len, date, current, exact.unwrap_or(true))
                 .into_iter()
                 .map(|entry| entry.into())
                 .collect();

--- a/src/roas_trie.rs
+++ b/src/roas_trie.rs
@@ -521,7 +521,7 @@ impl RoasTrie {
         }
 
         // sort by date
-        all_files.sort_by(|a, b| a.file_date.cmp(&b.file_date));
+        all_files.sort_by_key(|a| a.file_date);
 
         for file in all_files {
             info!("processing {}", file.url.as_str());

--- a/src/roas_trie.rs
+++ b/src/roas_trie.rs
@@ -406,11 +406,19 @@ impl RoasTrie {
         max_len: Option<u8>,
         date: Option<NaiveDate>,
         current: Option<bool>,
+        exact: bool,
     ) -> Vec<RoasLookupEntry> {
         let mut entries = Vec::new();
 
-        // prefix filter
-        let iter = match prefix {
+        // prefix filter: exact match by default (fixes issue #9),
+        // falls back to matches() when exact=false for supernet/subnet inclusion
+        let iter: Vec<(IpNet, &HashMap<(u8, u32), RoasTrieEntry>)> = match prefix {
+            Some(prefix) if exact => {
+                match self.trie.exact_match(prefix) {
+                    Some(map) => vec![(prefix, map)],
+                    None => vec![],
+                }
+            }
             Some(prefix) => self.trie.matches(&prefix),
             None => self.trie.iter().collect(),
         };

--- a/src/roas_trie.rs
+++ b/src/roas_trie.rs
@@ -9,6 +9,9 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use tabled::Tabled;
 use tracing::info;
 
+/// Type alias for trie entries keyed by (max_len, origin).
+type RoasTrieMap = HashMap<(u8, u32), RoasTrieEntry>;
+
 const KNOWN_GAPS_STR: [(&str, &str); 25] = [
     ("2018-12-28", "2019-01-02"),
     ("2019-10-22", "2019-10-22"),
@@ -412,13 +415,11 @@ impl RoasTrie {
 
         // prefix filter: exact match by default (fixes issue #9),
         // falls back to matches() when exact=false for supernet/subnet inclusion
-        let iter: Vec<(IpNet, &HashMap<(u8, u32), RoasTrieEntry>)> = match prefix {
-            Some(prefix) if exact => {
-                match self.trie.exact_match(prefix) {
-                    Some(map) => vec![(prefix, map)],
-                    None => vec![],
-                }
-            }
+        let iter: Vec<(IpNet, &RoasTrieMap)> = match prefix {
+            Some(prefix) if exact => match self.trie.exact_match(prefix) {
+                Some(map) => vec![(prefix, map)],
+                None => vec![],
+            },
             Some(prefix) => self.trie.matches(&prefix),
             None => self.trie.iter().collect(),
         };
@@ -537,5 +538,85 @@ impl RoasTrie {
     pub fn replace(&mut self, other: RoasTrie) {
         self.trie = other.trie;
         self.latest_date = other.latest_date;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RoaEntry;
+    use chrono::NaiveDate;
+    use ipnet::IpNet;
+    use std::net::Ipv4Addr;
+    use std::str::FromStr;
+
+    fn make_entry(prefix: &str, asn: u32, max_len: i32, date: NaiveDate) -> RoaEntry {
+        RoaEntry {
+            tal: "test".to_string(),
+            prefix: IpNet::from_str(prefix).unwrap(),
+            max_len,
+            asn,
+            date,
+        }
+    }
+
+    fn build_test_trie() -> RoasTrie {
+        let date = NaiveDate::from_ymd_opt(2024, 1, 1).unwrap();
+        let entries = vec![
+            // supernet
+            make_entry("1.0.0.0/8", 64512, 8, date),
+            // exact prefix we will search for
+            make_entry("1.1.1.0/24", 13335, 24, date),
+            // subnet (more-specific)
+            make_entry("1.1.1.0/25", 64513, 25, date),
+        ];
+        let mut trie = RoasTrie::new();
+        trie.process_entries(&entries, true);
+        trie.compress_dates();
+        trie
+    }
+
+    #[test]
+    fn test_search_exact_returns_only_matching_prefix() {
+        let trie = build_test_trie();
+        let prefix = IpNet::V4(ipnet::Ipv4Net::new(Ipv4Addr::new(1, 1, 1, 0), 24).unwrap());
+
+        // exact=true should return only the /24 ROA
+        let results = trie.search(Some(prefix), None, None, None, None, true);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].prefix.to_string(), "1.1.1.0/24");
+        assert_eq!(results[0].origin, 13335);
+    }
+
+    #[test]
+    fn test_search_non_exact_includes_super_and_sub() {
+        let trie = build_test_trie();
+        let prefix = IpNet::V4(ipnet::Ipv4Net::new(Ipv4Addr::new(1, 1, 1, 0), 24).unwrap());
+
+        // exact=false should use matches(), which includes the supernet and subnet
+        let results = trie.search(Some(prefix), None, None, None, None, false);
+        let prefixes: Vec<String> = results.iter().map(|r| r.prefix.to_string()).collect();
+        assert!(prefixes.contains(&"1.0.0.0/8".to_string()));
+        assert!(prefixes.contains(&"1.1.1.0/24".to_string()));
+        assert!(prefixes.contains(&"1.1.1.0/25".to_string()));
+    }
+
+    #[test]
+    fn test_search_exact_no_match_returns_empty() {
+        let trie = build_test_trie();
+        // prefix not in trie
+        let prefix = IpNet::V4(ipnet::Ipv4Net::new(Ipv4Addr::new(2, 2, 2, 0), 24).unwrap());
+
+        let results = trie.search(Some(prefix), None, None, None, None, true);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_search_no_prefix_returns_all() {
+        let trie = build_test_trie();
+
+        // No prefix filter → return all entries regardless of exact flag
+        let results = trie.search(None, None, None, None, None, true);
+        assert_eq!(results.len(), 3);
     }
 }


### PR DESCRIPTION
## Changes

### 1. Fix issue #9 — exact prefix search by default
When querying `/search?prefix=1.1.1.0/24`, the `matches()` method in `ipnet-trie` was returning **all** stored prefixes under the shortest matching supernet (e.g., everything under `1.0.0.0/8`), not just ROAs for the queried prefix. This caused non-matching super and sub prefixes in results.

- Changed `search()` to use `exact_match()` by default (`exact=true`)
- Added `exact` query parameter to the API — set `?exact=false` to get the old behavior (include supernets/subnets)
- Updated the CLI lookup command to also use exact match by default

### 2. Add Docker CI workflow
Added `.github/workflows/docker.yml` (adapted from monocle's) that automatically builds and pushes `bgpkit/wayback-rpki` Docker images to Docker Hub:
- On `main` branch push → tagged as `bgpkit/wayback-rpki:main`
- On `v*` tag push → tagged as `bgpkit/wayback-rpki:{version}`, `{major}.{minor}`, and `latest`
- Multi-arch builds: `linux/amd64` and `linux/arm64`

Closes #9