### PR TITLE
ci: native per-platform Docker builds with cargo-chef and registry cache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,33 @@
-# flyctl launch added from .idea/.gitignore
-# Default ignored files
-.idea/shelf
-.idea/workspace.xml
-# Editor-based HTTP Client requests
-.idea/httpRequests
-# Datasource local storage ignored files
-.idea/dataSources
-.idea/dataSources.local.xml
+# Build artifacts
+target/
+debug/
+release/
 
-target
+# Git
+.git/
+.gitignore
+.github/
+
+# IDE and editor files
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Documentation (not needed for build)
+CHANGELOG.md
+README.md
+
+# Docker files (prevent recursive issues)
+Dockerfile
+docker-compose.yml
+.dockerignore
+
+# Misc
+*.log
+*.bak
+*.tmp
+.env
+.env.*

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,8 +16,18 @@ permissions:
   contents: read
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            architecture: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            architecture: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -50,20 +60,87 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          provenance: false
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=bgpkit/wayback-rpki,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=registry,ref=bgpkit/wayback-rpki:buildcache-${{ matrix.architecture }}
+          cache-to: type=registry,ref=bgpkit/wayback-rpki:buildcache-${{ matrix.architecture }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.architecture }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Derive minor version for manual dispatch
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        id: ver
+        run: |
+          version="${{ inputs.version }}"
+          major_minor=$(echo "$version" | cut -d. -f1,2)
+          echo "major_minor=$major_minor" >> "$GITHUB_OUTPUT"
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: bgpkit/wayback-rpki
+          # On tag push: type=semver → "1.0.5", "1.0", and "latest"
+          # On manual dispatch: type=raw uses the input version
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
+            type=raw,value=${{ inputs.version }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=${{ steps.ver.outputs.major_minor }},enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Build and push
-        uses: docker/build-push-action@v7
+      - name: Download digests
+        uses: actions/download-artifact@v4
         with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          provenance: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Create and push manifest list
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          DOCKER_METADATA_OUTPUT_JSON: ${{ steps.meta.outputs.json }}
+        run: |
+          args=()
+          while IFS= read -r tag; do
+            args+=(--tag "$tag")
+          done < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          for digest in *; do
+            args+=("bgpkit/wayback-rpki@sha256:$digest")
+          done
+          docker buildx imagetools create "${args[@]}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,35 @@
-# select build image
-FROM rust:1.90 AS build
+# syntax=docker/dockerfile:1
+FROM rust:1.90 AS chef
+WORKDIR /app
+RUN cargo install cargo-chef --locked
 
-# create a new empty shell project
-RUN USER=root cargo new --bin my_project
-WORKDIR /my_project
+# ------------------------------------------------------------------------------
+# Planner: extract dependency recipe from Cargo.toml + Cargo.lock + source
+# structure. Does NOT compile.
+# ------------------------------------------------------------------------------
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-# copy your source tree
-COPY ./src ./src
-COPY ./Cargo.toml .
-COPY ./Cargo.lock .
+# ------------------------------------------------------------------------------
+# Builder: compile dependencies from recipe, then the real application source.
+# The dependency-cook layer is only invalidated when the dependency tree changes.
+# ------------------------------------------------------------------------------
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    cargo chef cook --release --recipe-path recipe.json
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    cargo build --release && \
+    cp /app/target/release/wayback-rpki /usr/local/bin/wayback-rpki
 
-# build for release
-RUN cargo build --release
-
-
-# our final base
+# ------------------------------------------------------------------------------
+# Runtime image
+# ------------------------------------------------------------------------------
 FROM debian:bookworm-slim
-
-# copy the build artifact from the build stage
-COPY --from=build /my_project/target/release/wayback-rpki /usr/local/bin/wayback-rpki
+COPY --from=builder /usr/local/bin/wayback-rpki /usr/local/bin/wayback-rpki
 
 WORKDIR /wayback-rpki
 
-ENTRYPOINT bash -c '/usr/local/bin/wayback-rpki serve --bootstrap --host 0.0.0.0 --port 40065'
+ENTRYPOINT ["/usr/local/bin/wayback-rpki", "serve", "--bootstrap", "--host", "0.0.0.0", "--port", "40065"]

--- a/src/roas_trie.rs
+++ b/src/roas_trie.rs
@@ -253,7 +253,7 @@ impl RoasTrie {
             }
 
             for (_prefix, map) in self.trie.iter_mut() {
-                for (_key, entry) in map.iter_mut() {
+                for entry in map.values_mut() {
                     let mut should_compress = false;
                     for i in 0..entry.dates_compressed.len() - 1 {
                         // let (start, end) = entry.dates_compressed[i];
@@ -276,7 +276,7 @@ impl RoasTrie {
     fn update_latest_date(&mut self) {
         let mut latest_date = 0;
         for (_prefix, map) in self.trie.iter() {
-            for (_key, entry) in map.iter() {
+            for entry in map.values() {
                 if let Some(date) = entry.dates.iter().max() {
                     if *date > latest_date {
                         latest_date = *date;
@@ -348,7 +348,7 @@ impl RoasTrie {
     pub fn compress_dates(&mut self) {
         info!("compressing dates into date ranges...");
         for (_prefix, map) in self.trie.iter_mut() {
-            for (_key, entry) in map.iter_mut() {
+            for entry in map.values_mut() {
                 entry.full_compress();
             }
         }


### PR DESCRIPTION
## Summary

Same optimization as bgpkit/monocle#144:
- Replaced QEMU-emulated multi-platform Docker build with native per-platform builds
- Added `cargo-chef` to Dockerfile for dependency-layer caching
- Switched BuildKit cache from GHA to registry-based cache

## Changes

### `Dockerfile`
- Three-stage cargo-chef pattern: `chef` → `planner` → `builder`
- Dependencies compiled from recipe in a cacheable layer separate from application source
- `RUN --mount=type=cache` for Cargo registry
- Preserved existing ENTRYPOINT with serve + bootstrap flags

### `.github/workflows/docker.yml`
- Split single QEMU job into matrix:
  - `linux/amd64` on `ubuntu-latest`
  - `linux/arm64` on `ubuntu-24.04-arm` (native ARM runner)
- Each build pushes by digest; `merge` job assembles multi-arch OCI image index
- Per-platform registry cache (`bgpkit/wayback-rpki:buildcache-{arch}`)
- Preserved `workflow_dispatch` manual trigger with version input
- Preserved `provenance: false`

### `.dockerignore`
- Replaced minimal flyctl-era ignore with comprehensive ignore matching monocle's pattern

## Verification

- Local Docker build succeeded; binary reports `wayback-rpki 1.0.5`
- `actionlint` passes
- Repeated local build confirmed all layers cached