### PR TITLE
prefix-trie + rkyv zero-copy mmap with legacy transition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,15 +92,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
-name = "async-trait"
-version = "0.1.89"
+name = "array-const-fn-init"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "8bcb85e548c05d407fa6faff46b750ba287714ef32afc0f5e15b4641ffd6affb"
 
 [[package]]
 name = "atomic-waker"
@@ -109,50 +104,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "attohttpc"
-version = "0.28.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a9b245ba0739fc90935094c29adbaee3f977218b5fb95e822e261cda7f56a3"
-dependencies = [
- "http 1.3.1",
- "log",
- "rustls",
- "serde",
- "serde_json",
- "url",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-creds"
-version = "0.37.0"
+name = "aws-lc-rs"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f84143206b9c72b3c5cb65415de60c7539c79cd1559290fddec657939131be0"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
- "attohttpc",
- "home",
- "log",
- "quick-xml",
- "rust-ini",
- "serde",
- "thiserror 1.0.69",
- "time",
- "url",
+ "aws-lc-sys",
+ "zeroize",
 ]
 
 [[package]]
-name = "aws-region"
-version = "0.25.5"
+name = "aws-lc-sys"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aed3f9c7eac9be28662fdb3b0f4d1951e812f7c64fed4f0327ba702f459b3b"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
- "thiserror 1.0.69",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -165,7 +142,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.3.1",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
@@ -197,7 +174,7 @@ checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
+ "http",
  "http-body",
  "http-body-util",
  "mime",
@@ -252,6 +229,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
@@ -266,10 +249,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bytecheck"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "rancor",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "bytecount"
@@ -290,6 +305,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65193589c6404eb80b450d618eaf9a2cafaaafd57ecce47370519ef674a7bd44"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -301,9 +318,20 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core",
+]
 
 [[package]]
 name = "chrono"
@@ -359,6 +387,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,23 +421,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-random"
-version = "0.1.18"
+name = "const-oid"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
-dependencies = [
- "const-random-macro",
-]
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
-name = "const-random-macro"
-version = "0.1.16"
+name = "core-foundation"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
- "getrandom 0.2.16",
- "once_cell",
- "tiny-keccak",
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -408,6 +447,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -447,12 +495,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,13 +505,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.5.3"
+name = "crypto-common"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "powerfmt",
- "serde",
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]
@@ -478,9 +559,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -495,19 +588,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "dlv-list"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
-dependencies = [
- "const-random",
-]
-
-[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
@@ -538,9 +628,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -555,6 +645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -572,6 +663,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -667,21 +764,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.5+wasi-0.2.4",
+ "rand_core",
  "wasm-bindgen",
 ]
 
@@ -702,7 +799,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.3.1",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -712,27 +809,21 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -746,27 +837,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
-name = "home"
-version = "0.5.11"
+name = "hmac"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -787,7 +867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.3.1",
+ "http",
 ]
 
 [[package]]
@@ -798,7 +878,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
+ "http",
  "http-body",
  "pin-project-lite",
 ]
@@ -816,6 +896,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,7 +915,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.3.1",
+ "http",
  "http-body",
  "httparse",
  "httpdate",
@@ -844,15 +933,16 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.3.1",
+ "http",
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.2",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -866,7 +956,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http",
  "http-body",
  "hyper",
  "ipnet",
@@ -1039,7 +1129,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "cfg-if",
  "libc",
 ]
@@ -1058,7 +1148,7 @@ checksum = "0bfa31eccd160220ed5765820b282754ec7e9b36a8f6ea65e08fc0c31c9058cc"
 dependencies = [
  "bincode",
  "ipnet",
- "prefix-trie",
+ "prefix-trie 0.6.0",
 ]
 
 [[package]]
@@ -1084,6 +1174,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jiff"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,9 +1231,9 @@ dependencies = [
 
 [[package]]
 name = "lazy-regex"
-version = "3.4.1"
+version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60c7310b93682b36b98fa7ea4de998d3463ccbebd94d935d6b48ba5b6ffa7126"
+checksum = "191898e17ddee19e60bccb3945aa02339e81edd4a8c50e21fd4d48cdecda7b29"
 dependencies = [
  "lazy-regex-proc_macros",
  "once_cell",
@@ -1106,9 +1242,9 @@ dependencies = [
 
 [[package]]
 name = "lazy-regex-proc_macros"
-version = "3.4.1"
+version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba01db5ef81e17eb10a5e0f2109d1b3a3e29bac3070fdbd7d156bf7dbd206a1"
+checksum = "c35dc8b0da83d1a9507e12122c80dea71a9c7c613014347392483a83ea593e04"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1127,6 +1263,15 @@ name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c10501e7805cee23da17c7790e59df2870c0d4043ec6d03f67d31e2b53e77415"
+dependencies = [
+ "zlib-rs",
+]
 
 [[package]]
 name = "litemap"
@@ -1174,27 +1319,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
-name = "maybe-async"
-version = "0.2.10"
+name = "md-5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "cfg-if",
+ "digest 0.11.3",
 ]
-
-[[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mime"
@@ -1218,8 +1365,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "munge"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1232,28 +1399,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -1279,28 +1430,30 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "oneio"
-version = "0.19.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c12bd5bc5be5df8a4ccad484b589c9e5c7798026b7abcd4d02a6187535f4160"
+checksum = "cd0d54e0e058b4dbb9a171a0d6fcd8971955c991023fd9055dbba49b7f60745e"
 dependencies = [
  "dotenvy",
  "flate2",
+ "hex",
+ "hmac 0.12.1",
+ "percent-encoding",
+ "quick-xml 0.38.4",
  "reqwest",
- "rust-s3",
+ "rustls",
+ "rusty-s3",
+ "sha2 0.10.9",
  "suppaftp",
- "thiserror 2.0.16",
+ "thiserror",
  "xz2",
 ]
 
 [[package]]
-name = "ordered-multimap"
-version = "0.7.3"
+name = "openssl-probe"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
-dependencies = [
- "dlv-list",
- "hashbrown 0.14.5",
-]
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "papergrid"
@@ -1373,27 +1526,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "zerovec",
-]
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
 ]
 
 [[package]]
@@ -1404,6 +1551,20 @@ checksum = "eb5f930995ba4986bd239ba8d8fded67cad82d1db329c4f316f312847cba16aa"
 dependencies = [
  "ipnet",
  "num-traits",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6369af434551b9bf8be05ab871ac1263687d6f0c9485e6d781f904f3e06d7d03"
+dependencies = [
+ "array-const-fn-init",
+ "either",
+ "ipnet",
+ "num-traits",
+ "rkyv",
+ "smallvec",
 ]
 
 [[package]]
@@ -1438,10 +1599,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-xml"
-version = "0.32.0"
+name = "ptr_meta"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
  "serde",
@@ -1449,9 +1639,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -1461,7 +1651,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.16",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -1469,20 +1659,21 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.3",
+ "getrandom 0.4.3",
  "lru-slab",
  "rand",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.16",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1490,16 +1681,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1513,37 +1704,43 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "rand"
-version = "0.9.2"
+name = "rancor"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "daff8b7b3ccf5f7ba270b3e7a0a4d4c701c5797e38dec27c7e2c3dbb830fed1c"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "ptr_meta",
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
+name = "rand"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom 0.4.3",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "getrandom 0.3.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -1572,7 +1769,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -1605,6 +1802,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
+name = "rend"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "663ba70707f96e871406fe10d68128412e619b06d1d47cb91c3a4c6501176240"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,7 +1823,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 1.3.1",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
@@ -1630,6 +1836,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -1646,7 +1853,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.2",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1664,43 +1871,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-ini"
-version = "0.21.3"
+name = "rkyv"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+checksum = "815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874"
 dependencies = [
- "cfg-if",
- "ordered-multimap",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
 ]
 
 [[package]]
-name = "rust-s3"
-version = "0.35.1"
+name = "rkyv_derive"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3df3f353b1f4209dcf437d777cda90279c397ab15a0cd6fd06bd32c88591533"
+checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
 dependencies = [
- "async-trait",
- "attohttpc",
- "aws-creds",
- "aws-region",
- "base64",
- "bytes",
- "cfg-if",
- "hex",
- "hmac",
- "http 0.2.12",
- "log",
- "maybe-async",
- "md5",
- "percent-encoding",
- "quick-xml",
- "serde",
- "serde_derive",
- "serde_json",
- "sha2",
- "thiserror 1.0.69",
- "time",
- "url",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1711,9 +1908,9 @@ checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustls"
@@ -1721,6 +1918,7 @@ version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -1728,6 +1926,18 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1746,6 +1956,7 @@ version = "0.103.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a37813727b78798e53c2bec3f5e8fe12a6d6f8389bf9ca7802add4c9905ad8"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1758,16 +1969,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rusty-s3"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15ec4851cde7bd44c6b1dbd7e68f70ac50f9dec29bb1f1ffd69426578af02d6b"
+dependencies = [
+ "base64",
+ "hmac 0.13.0",
+ "jiff",
+ "md-5",
+ "percent-encoding",
+ "quick-xml 0.39.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "url",
+ "zeroize",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+dependencies = [
+ "bitflags 2.9.4",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -1842,8 +2104,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1871,6 +2144,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1878,9 +2157,9 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
@@ -1912,16 +2191,16 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "suppaftp"
-version = "7.0.3"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3453e9f37ec7f6b5c18e1fbb1aa9900ba6a02fb392bfd2bb4e3f78f893eee1"
+checksum = "69a15b325bbe0a1f85de3dbf988a3a14e9cd321537dffcbf6641381dd6d7586f"
 dependencies = [
  "chrono",
  "futures-lite",
  "lazy-regex",
  "log",
  "rustls",
- "thiserror 2.0.16",
+ "thiserror",
 ]
 
 [[package]]
@@ -1990,31 +2269,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl 2.0.16",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2035,45 +2294,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "time"
-version = "0.3.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
-dependencies = [
- "deranged",
- "num-conv",
- "powerfmt",
- "serde",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
-
-[[package]]
-name = "time-macros"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
-dependencies = [
- "num-conv",
- "time-core",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -2177,10 +2397,10 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "bytes",
  "futures-util",
- "http 1.3.1",
+ "http",
  "http-body",
  "iri-string",
  "pin-project-lite",
@@ -2267,9 +2487,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -2326,6 +2546,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2357,24 +2587,6 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasi"
-version = "0.14.5+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
-dependencies = [
- "wasip2",
-]
-
-[[package]]
-name = "wasip2"
-version = "1.0.0+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
-dependencies = [
- "wit-bindgen",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2463,7 +2675,7 @@ dependencies = [
 
 [[package]]
 name = "wayback-rpki"
-version = "1.0.5"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2474,11 +2686,12 @@ dependencies = [
  "indicatif",
  "ipnet",
  "ipnet-trie",
- "num_cpus",
+ "memmap2",
  "oneio",
+ "prefix-trie 0.10.1",
  "rayon",
  "regex",
- "reqwest",
+ "rkyv",
  "serde",
  "serde_json",
  "tabled",
@@ -2510,18 +2723,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.11"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.2",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2757,12 +2961,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
-name = "wit-bindgen"
-version = "0.45.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
-
-[[package]]
 name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2799,26 +2997,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2880,3 +3058,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,13 +42,9 @@ axum = "0.8"
 tower-http = { version = "0.6", features = ["cors"] }
 tokio = { version = "1", features = ["full"] }
 
-# legacy v1 (bincode + ipnet-trie) import support
-ipnet-trie = { version = "0.3.0", features = ["export"], optional = true }
-bincode = { version = "2.0.1", optional = true }
-
-[features]
-default = []
-legacy = ["dep:ipnet-trie", "dep:bincode"]
+# legacy v1 (bincode + ipnet-trie) — always included for transition period
+ipnet-trie = { version = "0.3.0", features = ["export"] }
+bincode = "2.0.1"
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.tar.gz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayback-rpki"
-version = "1.0.5"
+version = "2.0.0"
 authors = ["Mingwei Zhang <mingwei@bgpkit.com>"]
 edition = "2021"
 license = "MIT"
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/wayback-rpki"
 default-run = "wayback-rpki"
 description = "A command-line tool to provide API for RPKI ROAs lookup with historical data"
 keywords = ["bgp", "network", "rpki"]
+rust-version = "1.81"
 
 [[bin]]
 name = "wayback-rpki"
@@ -18,7 +19,7 @@ path = "src/bin/main.rs"
 [dependencies]
 
 anyhow = "1"
-oneio = { version = "0.19.0", default-features = false, features = ["https", "xz", "gz", "s3"] }
+oneio = { version = "0.24", default-features = false, features = ["https", "xz", "gz", "s3"] }
 chrono = "0.4.38"
 dotenvy = "0.15"
 indicatif = "0.18.0"
@@ -27,13 +28,12 @@ rayon = "1.5.1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
-reqwest = { version = "0.12.7", default-features = false, features = ["blocking"] }
 clap = { version = "4", features = ["derive"] }
-num_cpus = "1"
 tracing = "0.1"
 tracing-subscriber = "0.3.3"
-ipnet-trie = { version = "0.3.0", features = ["export"] }
-bincode = "2.0.1"
+prefix-trie = { version = "0.10", features = ["ipnet", "rkyv"] }
+rkyv = "0.8"
+memmap2 = "0.9"
 
 tabled = "0.20.0"
 
@@ -41,6 +41,14 @@ tabled = "0.20.0"
 axum = "0.8"
 tower-http = { version = "0.6", features = ["cors"] }
 tokio = { version = "1", features = ["full"] }
+
+# legacy v1 (bincode + ipnet-trie) import support
+ipnet-trie = { version = "0.3.0", features = ["export"], optional = true }
+bincode = { version = "2.0.1", optional = true }
+
+[features]
+default = []
+legacy = ["dep:ipnet-trie", "dep:bincode"]
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.tar.gz"

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # ------------------------------------------------------------------------------
 # Runtime image
 # ------------------------------------------------------------------------------
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 COPY --from=builder /usr/local/bin/wayback-rpki /usr/local/bin/wayback-rpki
 
 WORKDIR /wayback-rpki

--- a/README.md
+++ b/README.md
@@ -279,7 +279,9 @@ files are transport/backup artifacts only and are decompressed before serving.
 During the v2 transition, `.bin`/`.bin.gz` paths retain the legacy in-memory
 backend. A missing `roas_trie.rkyv` is automatically generated from a sibling
 `roas_trie.bin.gz` or `roas_trie.bin` **before any bootstrap download is
-attempted**, without prompting. Explicit conversion is also available as
+attempted**, without prompting. If neither exists and the remote `.rkyv.gz`
+bootstrap is unavailable, bootstrap downloads the remote `.bin.gz` and converts
+it locally. Explicit conversion is also available as
 `wayback-rpki roas_trie.bin.gz convert --from roas_trie.bin.gz roas_trie.rkyv`.
 
 | `compress_dates()` | Merge consecutive dates into ranges |

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Commands:
   serve     Start the API server
 
 Options:
-  -p, --path <PATH>      Trie archive path; `.rkyv` uses mmap and `.bin[.gz]` uses legacy in-memory mode [default: roas_trie.rkyv]
+  <PATH>                 Trie archive path; `.rkyv` uses mmap and `.bin[.gz]` uses legacy in-memory mode [default: roas_trie.rkyv]
   -b, --bootstrap        Download bootstrap file if the data file doesn't exist
       --env <ENV>        Path to an environment variable file
   -h, --help             Print help
@@ -278,8 +278,9 @@ files are transport/backup artifacts only and are decompressed before serving.
 
 During the v2 transition, `.bin`/`.bin.gz` paths retain the legacy in-memory
 backend. A missing `roas_trie.rkyv` is automatically generated from a sibling
-`roas_trie.bin.gz` or `roas_trie.bin` without prompting. Explicit conversion is
-also available as `wayback-rpki convert --from roas_trie.bin.gz roas_trie.rkyv`.
+`roas_trie.bin.gz` or `roas_trie.bin` **before any bootstrap download is
+attempted**, without prompting. Explicit conversion is also available as
+`wayback-rpki roas_trie.bin.gz convert --from roas_trie.bin.gz roas_trie.rkyv`.
 
 | `compress_dates()` | Merge consecutive dates into ranges |
 | `fill_gaps()` | Fill known historical data gaps |

--- a/README.md
+++ b/README.md
@@ -220,12 +220,12 @@ use wayback_rpki::{crawl_tal_after, parse_roas_csv, get_tal_urls, RoaEntry, RoaF
 ### Trie Storage (`roas_trie.rs`)
 
 ```rust
-use wayback_rpki::RoasTrie;
+use wayback_rpki::{RoasTrie, RoasTrieMut};
 use ipnet::IpNet;
 use chrono::NaiveDate;
 
-// Load a pre-built trie
-let trie = RoasTrie::load("roas_trie.bin.gz")?;
+// Open a pre-built trie (memory-mapped, zero-copy)
+let trie = RoasTrie::open("roas_trie.rkyv")?;
 
 // Search with filters (exact=true by default)
 let results = trie.search(
@@ -251,22 +251,29 @@ let date_ts = NaiveDate::from_ymd_opt(2024, 1, 1).unwrap()
 let validation = trie.validate(&"1.1.1.0/24".parse().unwrap(), 13335, date_ts);
 // → RpkiValidation::Valid
 
-// Save the trie
-trie.dump("roas_trie.bin.gz")?;
+// Build / update (mutable builder), then serialize
+let mut builder = RoasTrieMut::new();
+builder.process_entries(&entries, true)?;
+builder.dump("roas_trie.rkyv")?;
 ```
 
-#### Key `RoasTrie` Methods
+#### Key Types
 
-| Method | Description |
-|--------|-------------|
-| `new()` | Create an empty trie |
-| `load(path)` | Load from a `.bin.gz` file |
-| `dump(path)` | Save to a `.bin.gz` file |
-| `process_entries(entries, bootstrap)` | Insert ROA entries |
-| `search(prefix, origin, max_len, date, current, exact)` | Query with filters |
-| `lookup_prefix(prefix)` | Get all ROAs for a prefix (includes super/subnets) |
-| `validate(prefix, origin, date_ts)` | RPKI validation → `Valid` / `Invalid` / `Unknown` |
-| `update(tal, until)` | Incremental update from RIPE |
+| Type | Role |
+|------|------|
+| `RoasTrie` | Read-only query handle over an rkyv archive (mmap or in-memory) |
+| `RoasTrieMut` | Mutable builder: `new`, `load_mut`, `process_entries`, `update`, `dump` |
+| `RoasTrie::open(path)` | Memory-map an archive (near-zero heap usage) |
+| `RoasTrieMut::load_mut(path)` | Load for mutation (update / fix flows) |
+| `RoasTrie::search(...)` | Query with filters |
+| `RoasTrie::lookup_prefix(prefix)` | All ROAs covering a prefix (super + subnets) |
+| `RoasTrie::validate(...)` | RPKI validation → `Valid` / `Invalid` / `Unknown` |
+
+The on-disk format is a raw `rkyv` archive (`RoasTrieData` with header metadata
+and a `JointPrefixMap`). v1 `roas_trie.bin.gz` archives can be converted with
+`wayback-rpki convert --from roas_trie.bin.gz roas_trie.rkyv` (requires the
+`legacy` cargo feature).
+
 | `compress_dates()` | Merge consecutive dates into ranges |
 | `fill_gaps()` | Fill known historical data gaps |
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ currency status.
 
 - **Historical ROA data** — Full history from 2011 onward, sourced from all 5 RIR TALs
   (Afrinic, APNIC, ARIN, LACNIC, RIPE NCC)
-- **Fast prefix trie** — `ipnet-trie` backed storage with compressed date ranges for
-  efficient memory usage (~1M+ ROAs in memory)
+- **Zero-copy mmap trie** — `prefix-trie` + rkyv backed v2 storage; the raw
+  local archive is memory-mapped rather than loaded into heap memory
+- **Legacy transition mode** — `.bin`/`.bin.gz` inputs retain the v1 `ipnet-trie`
+  in-memory backend; `.rkyv` inputs select zero-copy mmap automatically
 - **REST API** — Query by prefix, ASN, max-length, date, and current/expired status
 - **Incremental updates** — Background thread fetches new data every 8 hours
 - **Backup to R2/S3** — Automatic backup of the trie to Cloudflare R2 or any S3-compatible
@@ -54,8 +56,9 @@ Start the API with a one-command bootstrap (downloads pre-built trie from
 wayback-rpki serve --bootstrap
 ```
 
-This downloads the bootstrap trie file, loads it into memory, and starts an HTTP API
-server on `0.0.0.0:40065`. The server will automatically update its data every 8 hours.
+This downloads the gzip-compressed bootstrap transport artifact, streams it into
+an uncompressed local `roas_trie.rkyv` archive, then memory-maps that raw file
+for the API on `0.0.0.0:40065`. The server updates every 8 hours.
 
 ## CLI Usage
 
@@ -70,7 +73,7 @@ Commands:
   serve     Start the API server
 
 Options:
-  -p, --path <PATH>      File path to the trie data file [default: roas_trie.bin.gz]
+  -p, --path <PATH>      Trie archive path; `.rkyv` uses mmap and `.bin[.gz]` uses legacy in-memory mode [default: roas_trie.rkyv]
   -b, --bootstrap        Download bootstrap file if the data file doesn't exist
       --env <ENV>        Path to an environment variable file
   -h, --help             Print help
@@ -269,10 +272,14 @@ builder.dump("roas_trie.rkyv")?;
 | `RoasTrie::lookup_prefix(prefix)` | All ROAs covering a prefix (super + subnets) |
 | `RoasTrie::validate(...)` | RPKI validation → `Valid` / `Invalid` / `Unknown` |
 
-The on-disk format is a raw `rkyv` archive (`RoasTrieData` with header metadata
-and a `JointPrefixMap`). v1 `roas_trie.bin.gz` archives can be converted with
-`wayback-rpki convert --from roas_trie.bin.gz roas_trie.rkyv` (requires the
-`legacy` cargo feature).
+The on-disk v2 format is a raw `rkyv` archive (`RoasTrieData` with header
+metadata and a `JointPrefixMap`). Raw `.rkyv` files are mmap-ready; `.rkyv.gz`
+files are transport/backup artifacts only and are decompressed before serving.
+
+During the v2 transition, `.bin`/`.bin.gz` paths retain the legacy in-memory
+backend. A missing `roas_trie.rkyv` is automatically generated from a sibling
+`roas_trie.bin.gz` or `roas_trie.bin` without prompting. Explicit conversion is
+also available as `wayback-rpki convert --from roas_trie.bin.gz roas_trie.rkyv`.
 
 | `compress_dates()` | Merge consecutive dates into ranges |
 | `fill_gaps()` | Fill known historical data gaps |
@@ -283,7 +290,7 @@ The `serve` subcommand supports the following environment variables:
 
 | Variable | Description |
 |----------|-------------|
-| `WAYBACK_BACKUP_TO` | Backup destination (`r2://bucket/key` for S3/R2, or local path) |
+| `WAYBACK_BACKUP_TO` | Backup destination (`r2://bucket/key` for S3/R2, or local path). A destination ending in `.rkyv.gz` is gzip-compressed for transport; the local serving archive remains raw/mmap-ready. |
 | `WAYBACK_BACKUP_HEARTBEAT_URL` | URL to ping after successful backup (e.g., UptimeRobot) |
 | `AWS_REGION` | S3/R2 region (required for R2 backups) |
 | `AWS_ENDPOINT` | S3/R2 endpoint (required for R2 backups) |

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,3 +1,4 @@
+use crate::legacy::LegacyRoasTrie;
 use crate::{RoasTrie, RpkiValidation};
 use axum::extract::{Query, State};
 use axum::http::{Method, StatusCode};
@@ -14,7 +15,70 @@ use tokio::sync::RwLock;
 use tower_http::cors::{Any, CorsLayer};
 use tracing::warn;
 
-pub type SharedTrie = Arc<RwLock<RoasTrie>>;
+/// The trie backend — either v2 (rkyv mmap) or v1 (legacy in-memory bincode).
+/// Both implement the same query surface (search/validate/counts/latest_date).
+pub enum TrieBackend {
+    V2(RoasTrie),
+    V1(LegacyRoasTrie),
+}
+
+impl TrieBackend {
+    pub fn search(
+        &self,
+        prefix: Option<IpNet>,
+        origin: Option<u32>,
+        max_len: Option<u8>,
+        date: Option<NaiveDate>,
+        current: Option<bool>,
+        exact: bool,
+    ) -> Vec<crate::RoasLookupEntry> {
+        match self {
+            TrieBackend::V2(t) => t.search(prefix, origin, max_len, date, current, exact),
+            TrieBackend::V1(t) => t.search(prefix, origin, max_len, date, current, exact),
+        }
+    }
+
+    pub fn validate(&self, prefix: &IpNet, origin: u32, date_ts: i64) -> RpkiValidation {
+        match self {
+            TrieBackend::V2(t) => t.validate(prefix, origin, date_ts),
+            TrieBackend::V1(t) => t.validate(prefix, origin, date_ts),
+        }
+    }
+
+    pub fn counts(&self) -> (u64, u64) {
+        match self {
+            TrieBackend::V2(t) => t.counts(),
+            TrieBackend::V1(t) => {
+                let mut v4 = 0u64;
+                let mut v6 = 0u64;
+                for (prefix, entries) in t.trie.iter() {
+                    let count = entries.len() as u64;
+                    match prefix {
+                        IpNet::V4(_) => v4 += count,
+                        IpNet::V6(_) => v6 += count,
+                    }
+                }
+                (v4, v6)
+            }
+        }
+    }
+
+    pub fn latest_date_ts(&self) -> i64 {
+        match self {
+            TrieBackend::V2(t) => t.latest_date_ts(),
+            TrieBackend::V1(t) => t.latest_date,
+        }
+    }
+
+    pub fn format_version(&self) -> u32 {
+        match self {
+            TrieBackend::V2(_) => crate::FORMAT_VERSION,
+            TrieBackend::V1(_) => 1,
+        }
+    }
+}
+
+pub type SharedTrie = Arc<RwLock<TrieBackend>>;
 
 #[derive(Args, Debug, Serialize, Deserialize)]
 pub struct RoasSearchQuery {
@@ -101,11 +165,15 @@ fn bad_request(msg: &str) -> axum::response::Response {
 async fn health(State(state): State<SharedTrie>) -> impl IntoResponse {
     let trie = state.read().await;
     let (ipv4_count, ipv6_count) = trie.counts();
-    Json(json! ({
+    Json(json!({
         "ipv4_roas_count": ipv4_count,
         "ipv6_roas_count": ipv6_count,
-        "latest_date": trie.get_latest_date().to_string(),
-        "format_version": crate::FORMAT_VERSION,
+        "latest_date": DateTime::from_timestamp(trie.latest_date_ts(), 0)
+            .unwrap()
+            .naive_utc()
+            .date()
+            .to_string(),
+        "format_version": trie.format_version(),
     }))
     .into_response()
 }
@@ -136,6 +204,7 @@ async fn search(
 
     let trie = state.read().await;
     let latest_ts = trie.latest_date_ts();
+    let format_version = trie.format_version();
     let latest_date = DateTime::from_timestamp(latest_ts, 0)
         .unwrap()
         .naive_utc()
@@ -179,7 +248,7 @@ async fn search(
         data: result_entries,
         meta: Some(Meta {
             latest_date: latest_date.to_string(),
-            format_version: crate::FORMAT_VERSION,
+            format_version,
         }),
         page,
         page_size,

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,17 +1,20 @@
-use crate::RoasTrie;
+use crate::{RoasTrie, RpkiValidation};
 use axum::extract::{Query, State};
 use axum::http::{Method, StatusCode};
 use axum::response::IntoResponse;
 use axum::routing::get;
 use axum::{Json, Router};
-use chrono::DateTime;
+use chrono::{DateTime, NaiveDate};
 use clap::Args;
+use ipnet::IpNet;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tower_http::cors::{Any, CorsLayer};
 use tracing::warn;
+
+pub type SharedTrie = Arc<RwLock<RoasTrie>>;
 
 #[derive(Args, Debug, Serialize, Deserialize)]
 pub struct RoasSearchQuery {
@@ -42,7 +45,9 @@ pub struct RoasSearchQuery {
 
 #[derive(Serialize, Deserialize)]
 pub struct RoasSearchResult {
-    pub count: usize,
+    /// total number of matching entries (before pagination)
+    pub total: usize,
+    /// error message if any
     pub error: Option<String>,
     pub data: Vec<RoasSearchResultEntry>,
     pub meta: Option<Meta>,
@@ -53,6 +58,7 @@ pub struct RoasSearchResult {
 #[derive(Serialize, Deserialize)]
 pub struct Meta {
     pub latest_date: String,
+    pub format_version: u32,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -64,21 +70,49 @@ pub struct RoasSearchResultEntry {
     pub current: bool,
 }
 
-async fn health(State(state): State<Arc<RwLock<RoasTrie>>>) -> impl IntoResponse {
+#[derive(Args, Debug, Serialize, Deserialize)]
+pub struct ValidateQuery {
+    /// IP prefix to validate, e.g. `?prefix=1.1.1.0/24` (required)
+    prefix: String,
+
+    /// origin ASN to validate (required)
+    asn: u32,
+
+    /// date for historical validation, format: YYYY-MM-DD (default: latest)
+    date: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct ValidateResult {
+    pub prefix: String,
+    pub asn: u32,
+    pub date: String,
+    pub result: String,
+}
+
+fn bad_request(msg: &str) -> axum::response::Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(serde_json::json!({"error": msg})),
+    )
+        .into_response()
+}
+
+async fn health(State(state): State<SharedTrie>) -> impl IntoResponse {
     let trie = state.read().await;
-    let (ipv4_count, ipv6_count) = trie.trie.len();
-    let latest_ts = trie.latest_date;
+    let (ipv4_count, ipv6_count) = trie.counts();
     Json(json! ({
         "ipv4_roas_count": ipv4_count,
         "ipv6_roas_count": ipv6_count,
-        "latest_date": DateTime::from_timestamp(latest_ts, 0).unwrap().naive_utc().date().to_string(),
+        "latest_date": trie.get_latest_date().to_string(),
+        "format_version": crate::FORMAT_VERSION,
     }))
     .into_response()
 }
 
 async fn search(
     query: Query<RoasSearchQuery>,
-    State(state): State<Arc<RwLock<RoasTrie>>>,
+    State(state): State<SharedTrie>,
 ) -> impl IntoResponse {
     let page = query.page.unwrap_or(0);
     let mut page_size = query.page_size.unwrap_or(100);
@@ -89,36 +123,25 @@ async fn search(
 
     // Parse prefix and date early so we can return a clean 400 instead of
     // panicking (→ 500) on malformed input.
-    let prefix = match query.prefix.as_ref().map(|p| p.parse()) {
+    let prefix: Option<IpNet> = match query.prefix.as_ref().map(|p| p.parse()) {
         Some(Ok(p)) => Some(p),
-        Some(Err(_)) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({"error": "invalid prefix"})),
-            )
-                .into_response();
-        }
+        Some(Err(_)) => return bad_request("invalid prefix"),
         None => None,
     };
-    let date = match query.date.as_ref().map(|d| d.parse()) {
+    let date: Option<NaiveDate> = match query.date.as_ref().map(|d| d.parse()) {
         Some(Ok(d)) => Some(d),
-        Some(Err(_)) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({"error": "invalid date"})),
-            )
-                .into_response();
-        }
+        Some(Err(_)) => return bad_request("invalid date"),
         None => None,
     };
 
     let trie = state.read().await;
-    let latest_ts = trie.latest_date;
+    let latest_ts = trie.latest_date_ts();
     let latest_date = DateTime::from_timestamp(latest_ts, 0)
         .unwrap()
         .naive_utc()
         .date();
-    let mut results = trie.search(
+
+    let results = trie.search(
         prefix,
         query.asn,
         query.max_len,
@@ -126,9 +149,15 @@ async fn search(
         query.current,
         query.exact.unwrap_or(true),
     );
-    results.sort_by_key(|a| a.prefix);
+
+    let total = results.len();
+
+    // Results come back in deterministic trie (lexicographic prefix) order;
+    // paginate without an additional full sort.
     let result_entries = results
         .iter()
+        .skip(page * page_size)
+        .take(page_size)
         .map(|entry| RoasSearchResultEntry {
             prefix: entry.prefix.to_string(),
             max_len: entry.max_len,
@@ -144,19 +173,13 @@ async fn search(
         })
         .collect::<Vec<_>>();
 
-    // filter result entries by page and page_size
-    let result_entries = result_entries
-        .into_iter()
-        .skip(page * page_size)
-        .take(page_size)
-        .collect::<Vec<_>>();
-
     Json(RoasSearchResult {
-        count: result_entries.len(),
+        total,
         error: None,
         data: result_entries,
         meta: Some(Meta {
             latest_date: latest_date.to_string(),
+            format_version: crate::FORMAT_VERSION,
         }),
         page,
         page_size,
@@ -164,8 +187,45 @@ async fn search(
     .into_response()
 }
 
+async fn validate(
+    query: Query<ValidateQuery>,
+    State(state): State<SharedTrie>,
+) -> impl IntoResponse {
+    let prefix: IpNet = match query.prefix.parse() {
+        Ok(p) => p,
+        Err(_) => return bad_request("invalid prefix"),
+    };
+    let trie = state.read().await;
+    let latest_ts = trie.latest_date_ts();
+    let latest_date = DateTime::from_timestamp(latest_ts, 0)
+        .unwrap()
+        .naive_utc()
+        .date();
+    let date: NaiveDate = match query.date.as_ref().map(|d| d.parse()) {
+        Some(Ok(d)) => d,
+        Some(Err(_)) => return bad_request("invalid date"),
+        None => latest_date,
+    };
+    let date_ts = date.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp();
+
+    let result = trie.validate(&prefix, query.asn, date_ts);
+    let result_str = match result {
+        RpkiValidation::Valid => "valid",
+        RpkiValidation::Invalid => "invalid",
+        RpkiValidation::Unknown => "unknown",
+    };
+
+    Json(ValidateResult {
+        prefix: prefix.to_string(),
+        asn: query.asn,
+        date: date.to_string(),
+        result: result_str.to_string(),
+    })
+    .into_response()
+}
+
 pub async fn start_api_service(
-    trie_lock: Arc<RwLock<RoasTrie>>,
+    trie_lock: SharedTrie,
     host: String,
     port: u16,
     root: String,
@@ -178,6 +238,7 @@ pub async fn start_api_service(
 
     let app = Router::new()
         .route("/search", get(search))
+        .route("/validate", get(validate))
         .route("/health", get(health))
         .with_state(trie_lock)
         .layer(cors_layer);

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -3,6 +3,7 @@ use clap::{Parser, Subcommand};
 use indicatif::{ProgressBar, ProgressStyle};
 use ipnet::IpNet;
 use rayon::prelude::*;
+use std::path::Path;
 use std::process::exit;
 use std::sync::Arc;
 use std::thread;
@@ -10,13 +11,15 @@ use tabled::settings::Style;
 use tabled::Table;
 use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn, Level};
+use wayback_rpki::api::TrieBackend;
 use wayback_rpki::*;
 
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 #[clap(name = "wayback-rpki")]
 struct Cli {
-    /// file path to the trie archive (v2 rkyv format).
+    /// file path to the trie archive. Suffix determines the backend:
+    /// `.rkyv` → v2 mmap mode, `.bin`/`.bin.gz` → v1 legacy in-memory mode.
     #[clap(default_value = "roas_trie.rkyv", global = true)]
     path: String,
 
@@ -70,7 +73,7 @@ enum Opts {
         #[clap(short, long)]
         asn: Option<u32>,
 
-        /// IP prefix to search ROAs for, e.g. `?prefix=
+        /// IP prefix to search ROAs for
         #[clap(short, long)]
         prefix: Option<IpNet>,
 
@@ -78,7 +81,7 @@ enum Opts {
         #[clap(short, long)]
         max_len: Option<u8>,
 
-        /// limit the date of the ROAs, format: YYYY-MM-DD, e.g. `?date=2022-01-01`
+        /// limit the date of the ROAs, format: YYYY-MM-DD
         #[clap(short, long)]
         date: Option<NaiveDate>,
 
@@ -86,12 +89,11 @@ enum Opts {
         #[clap(short, long)]
         current: Option<bool>,
 
-        /// only return exact prefix matches (default: true); set to false to include supernets and subnets
+        /// only return exact prefix matches (default: true)
         #[clap(short, long)]
         exact: Option<bool>,
     },
     /// Convert a legacy v1 (bincode + ipnet-trie) archive to the v2 rkyv format
-    #[cfg(feature = "legacy")]
     Convert {
         /// path to the legacy v1 archive (e.g. roas_trie.bin.gz)
         #[clap(short, long)]
@@ -121,6 +123,37 @@ fn num_threads() -> usize {
         .unwrap_or(4)
 }
 
+/// Determine if a path is a v2 rkyv archive or a v1 bincode archive.
+fn is_rkyv_path(path: &str) -> bool {
+    path.ends_with(".rkyv")
+}
+
+/// Find a sibling legacy bin file for a given rkyv path.
+/// e.g. `roas_trie.rkyv` → check `roas_trie.bin.gz`, then `roas_trie.bin`
+fn find_sibling_bin(rkyv_path: &str) -> Option<String> {
+    let base = rkyv_path.strip_suffix(".rkyv").unwrap_or(rkyv_path);
+    for suffix in &[".bin.gz", ".bin"] {
+        let candidate = format!("{}{}", base, suffix);
+        if Path::new(&candidate).exists() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Auto-convert a legacy v1 `.bin[.gz]` archive to v2 rkyv at the given path.
+fn auto_convert(bin_path: &str, rkyv_path: &str) -> anyhow::Result<()> {
+    info!(
+        "auto-converting legacy archive {} → {} ...",
+        bin_path, rkyv_path
+    );
+    let legacy = wayback_rpki::legacy::LegacyRoasTrie::load(bin_path)?;
+    let mut builder = legacy.to_builder();
+    builder.dump(rkyv_path)?;
+    info!("auto-conversion complete: {}", rkyv_path);
+    Ok(())
+}
+
 fn main() {
     tracing_subscriber::fmt()
         .with_max_level(Level::INFO)
@@ -146,7 +179,7 @@ fn main() {
         }
     }
 
-    let path = opts.path;
+    let path = opts.path.clone();
 
     match opts.subcommands {
         Opts::Rebuild {
@@ -189,16 +222,17 @@ fn main() {
             });
 
             // dedicated writer thread
+            let path2 = path.clone();
             let handle = thread::spawn(move || {
                 let mut trie = RoasTrieMut::new();
                 for entries in receiver_entries.iter() {
                     trie.process_entries(&entries, true);
                 }
-                trie.dump(path.as_str()).unwrap();
+                trie.dump(path2.as_str()).unwrap();
                 info!(
                     "bootstrap finished: {} prefixes written to {}",
                     trie.len(),
-                    path
+                    path2
                 );
             });
 
@@ -226,10 +260,18 @@ fn main() {
         }
 
         Opts::Update { tal, until } => {
-            check_bootstrap_and_download(path.as_str(), opts.bootstrap);
-            let mut trie = RoasTrieMut::load(path.as_str()).unwrap();
-            trie.update(tal, until).unwrap();
-            trie.dump(path.as_str()).unwrap();
+            check_bootstrap_and_download(&path, opts.bootstrap);
+            ensure_data_available(&path);
+
+            if is_rkyv_path(&path) {
+                let mut trie = RoasTrieMut::load(&path).unwrap();
+                trie.update(tal, until).unwrap();
+                trie.dump(&path).unwrap();
+            } else {
+                let mut trie = wayback_rpki::legacy::LegacyRoasTrie::load(&path).unwrap();
+                trie.update(tal, until).unwrap();
+                trie.dump(&path).unwrap();
+            }
         }
 
         Opts::Search {
@@ -240,27 +282,44 @@ fn main() {
             current,
             exact,
         } => {
-            check_bootstrap_and_download(path.as_str(), opts.bootstrap);
-            let trie = RoasTrie::open(path.as_str()).unwrap();
-            let results: Vec<RoasLookupEntryTabled> = trie
-                .search(prefix, asn, max_len, date, current, exact.unwrap_or(true))
-                .into_iter()
-                .map(|entry| entry.into())
-                .collect();
+            check_bootstrap_and_download(&path, opts.bootstrap);
+            ensure_data_available(&path);
+
+            let results: Vec<RoasLookupEntryTabled> = if is_rkyv_path(&path) {
+                let trie = RoasTrie::open(&path).unwrap();
+                trie.search(prefix, asn, max_len, date, current, exact.unwrap_or(true))
+                    .into_iter()
+                    .map(|e| e.into())
+                    .collect()
+            } else {
+                let trie = wayback_rpki::legacy::LegacyRoasTrie::load(&path).unwrap();
+                trie.search(prefix, asn, max_len, date, current, exact.unwrap_or(true))
+                    .into_iter()
+                    .map(|e| e.into())
+                    .collect()
+            };
             println!("{}", Table::new(results).with(Style::markdown()));
         }
 
         Opts::Fix {} => {
-            check_bootstrap_and_download(path.as_str(), opts.bootstrap);
-            let mut trie = RoasTrieMut::load(path.as_str()).unwrap();
-            trie.fill_gaps();
-            trie.dump(path.as_str()).unwrap();
+            check_bootstrap_and_download(&path, opts.bootstrap);
+            ensure_data_available(&path);
+
+            if is_rkyv_path(&path) {
+                let mut trie = RoasTrieMut::load(&path).unwrap();
+                trie.fill_gaps();
+                trie.dump(&path).unwrap();
+            } else {
+                let mut trie = wayback_rpki::legacy::LegacyRoasTrie::load(&path).unwrap();
+                trie.fill_gaps();
+                trie.dump(&path).unwrap();
+            }
         }
 
-        #[cfg(feature = "legacy")]
         Opts::Convert { from } => {
-            let mut trie = wayback_rpki::legacy::load_legacy(&from).unwrap();
-            trie.dump(path.as_str()).unwrap();
+            let legacy = wayback_rpki::legacy::LegacyRoasTrie::load(&from).unwrap();
+            let mut builder = legacy.to_builder();
+            builder.dump(&path).unwrap();
             info!("converted legacy archive {} -> {}", from, path);
         }
 
@@ -272,7 +331,6 @@ fn main() {
         } => {
             let mut backup_destinations = vec![backup_to];
             if let Ok(p) = std::env::var("WAYBACK_BACKUP_TO") {
-                // replace backup_to with the env variable if it is set
                 backup_destinations.push(Some(p));
             }
             for backup_to in &backup_destinations {
@@ -285,10 +343,19 @@ fn main() {
                 info!("backup heartbeat will be sent to {}", backup_heartbeat_url);
             }
 
-            check_bootstrap_and_download(path.as_str(), opts.bootstrap);
-            let trie = RoasTrie::open(path.as_str()).unwrap();
-            let trie_lock = Arc::new(RwLock::new(trie));
+            check_bootstrap_and_download(&path, opts.bootstrap);
+            ensure_data_available(&path);
+
+            let backend = if is_rkyv_path(&path) {
+                info!("opening v2 rkyv archive (mmap mode): {}", path);
+                TrieBackend::V2(RoasTrie::open(&path).unwrap())
+            } else {
+                info!("opening v1 legacy archive (in-memory mode): {}", path);
+                TrieBackend::V1(wayback_rpki::legacy::LegacyRoasTrie::load(&path).unwrap())
+            };
+            let trie_lock: Arc<RwLock<TrieBackend>> = Arc::new(RwLock::new(backend));
             let timer_lock = trie_lock.clone();
+            let serve_path = path.clone();
 
             thread::spawn(move || {
                 let rt = get_tokio_runtime();
@@ -299,25 +366,32 @@ fn main() {
                         interval.tick().await;
 
                         info!("updating trie from latest data...");
-                        // Load the current archive into a mutable trie, update, and
-                        // write back atomically. The serving trie itself stays
-                        // memory-mapped; only the updater materializes data.
-                        let mut backup = match RoasTrieMut::load(path.as_str()) {
-                            Ok(t) => t,
-                            Err(e) => {
-                                error!("failed to load trie for update: {}", e);
-                                continue;
-                            }
+                        let rkyv_path = serve_path.clone();
+                        let is_rkyv = is_rkyv_path(&rkyv_path);
+
+                        let update_result = if is_rkyv {
+                            RoasTrieMut::load(&rkyv_path)
+                                .map_err(|e| e.to_string())
+                                .and_then(|mut t| {
+                                    t.update(None, None).map_err(|e| e.to_string())?;
+                                    t.dump(&rkyv_path).map_err(|e| e.to_string())?;
+                                    Ok(())
+                                })
+                        } else {
+                            wayback_rpki::legacy::LegacyRoasTrie::load(&rkyv_path)
+                                .map_err(|e| e.to_string())
+                                .and_then(|mut t| {
+                                    t.update(None, None).map_err(|e| e.to_string())?;
+                                    t.dump(&rkyv_path).map_err(|e| e.to_string())?;
+                                    Ok(())
+                                })
                         };
-                        if let Err(e) = backup.update(None, None) {
+
+                        if let Err(e) = update_result {
                             error!("trie update failed: {}", e);
                             continue;
                         }
-                        if let Err(e) = backup.dump(path.as_str()) {
-                            error!("failed to write updated trie to disk: {}", e);
-                            continue;
-                        }
-                        info!("updated trie written to disk: {}", path);
+                        info!("updated trie written to disk: {}", rkyv_path);
 
                         let mut to_send_heartbeat = false;
                         for backup_to in &backup_destinations {
@@ -326,31 +400,36 @@ fn main() {
                                 match oneio::s3_url_parse(backup_to) {
                                     Ok((bucket, key)) => {
                                         if oneio::s3_env_check().is_err() {
-                                            error!("s3 environment variables not set, skipping backup to s3");
+                                            error!(
+                                                "s3 environment variables not set, skipping backup to s3"
+                                            );
                                         } else {
-                                            match oneio::s3_upload(&bucket, &key, path.as_str()) {
+                                            match oneio::s3_upload(&bucket, &key, rkyv_path.as_str()) {
                                                 Ok(_) => {
                                                     info!("backup trie written to s3: {}", backup_to);
                                                     to_send_heartbeat = true;
                                                 }
                                                 Err(e) => {
-                                                    error!("failed to write backup trie to s3 {}: {}", backup_to, e);
+                                                    error!(
+                                                        "failed to write backup trie to s3 {}: {}",
+                                                        backup_to, e
+                                                    );
                                                 }
                                             }
                                         }
                                     }
-                                    Err(_) => {
-                                        // not an s3 url: make a file system copy
-                                        match std::fs::copy(&path, backup_to) {
-                                            Ok(_) => {
-                                                info!("backup trie written to disk: {}", backup_to);
-                                                to_send_heartbeat = true;
-                                            }
-                                            Err(e) => {
-                                                error!("failed to write backup trie to disk {}: {}", backup_to, e)
-                                            }
+                                    Err(_) => match std::fs::copy(&rkyv_path, backup_to) {
+                                        Ok(_) => {
+                                            info!("backup trie written to disk: {}", backup_to);
+                                            to_send_heartbeat = true;
                                         }
-                                    }
+                                        Err(e) => {
+                                            error!(
+                                                "failed to write backup trie to disk {}: {}",
+                                                backup_to, e
+                                            )
+                                        }
+                                    },
                                 }
                             }
                         }
@@ -364,18 +443,30 @@ fn main() {
                             }
                         }
 
-                        // Swap in the updated archive: re-map the file and replace.
+                        // Swap in the updated archive: re-open and replace.
                         info!("swapping serving trie to updated archive...");
-                        match RoasTrie::open(path.as_str()) {
-                            Ok(new_trie) => {
-                                let mut write_lock = timer_lock.write().await;
-                                *write_lock = new_trie;
-                                drop(write_lock);
-                                info!("serving trie swapped");
+                        let new_backend = if is_rkyv {
+                            match RoasTrie::open(&rkyv_path) {
+                                Ok(t) => Some(TrieBackend::V2(t)),
+                                Err(e) => {
+                                    error!("failed to re-open updated trie: {}", e);
+                                    None
+                                }
                             }
-                            Err(e) => {
-                                error!("failed to re-open updated trie: {}", e);
+                        } else {
+                            match wayback_rpki::legacy::LegacyRoasTrie::load(&rkyv_path) {
+                                Ok(t) => Some(TrieBackend::V1(t)),
+                                Err(e) => {
+                                    error!("failed to re-load legacy trie: {}", e);
+                                    None
+                                }
                             }
+                        };
+                        if let Some(b) = new_backend {
+                            let mut write_lock = timer_lock.write().await;
+                            *write_lock = b;
+                            drop(write_lock);
+                            info!("serving trie swapped");
                         }
 
                         info!("wait for {} seconds before next update", update_interval);
@@ -408,15 +499,43 @@ fn get_tokio_runtime() -> tokio::runtime::Runtime {
 
 /// Check if data file exists, and bootstrap if necessary
 fn check_bootstrap_and_download(path: &str, bootstrap: bool) {
-    if !std::path::Path::new(path).exists() {
-        // if file at `path` does not exist
-        if bootstrap {
-            // download bootstrap file
+    if !Path::new(path).exists() && bootstrap {
+        info!(
+            "downloading bootstrap file {} to {}",
+            REMOTE_BOOTSTRAP_URL, path
+        );
+        oneio::download(REMOTE_BOOTSTRAP_URL, path).unwrap();
+    }
+}
+
+/// Ensure the data file exists. For `.rkyv` paths, if the file is missing,
+/// attempt to find and auto-convert a sibling `.bin[.gz]` file.
+fn ensure_data_available(path: &str) {
+    if Path::new(path).exists() {
+        return;
+    }
+
+    // For rkyv paths, try to find a sibling legacy bin file and auto-convert
+    if is_rkyv_path(path) {
+        if let Some(bin_path) = find_sibling_bin(path) {
             info!(
-                "downloading bootstrap file {} to {}",
-                REMOTE_BOOTSTRAP_URL, path
+                "requested {} not found; auto-converting from sibling {}",
+                path, bin_path
             );
-            oneio::download(REMOTE_BOOTSTRAP_URL, path).unwrap();
+            match auto_convert(&bin_path, path) {
+                Ok(()) => return,
+                Err(e) => {
+                    error!("auto-conversion from {} failed: {}", bin_path, e);
+                }
+            }
         }
     }
+
+    // Still missing — the caller's check_bootstrap_and_download should have
+    // already handled the download case. If we reach here, there's no data.
+    error!(
+        "data file {} does not exist and no sibling bin file found",
+        path
+    );
+    exit(1);
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -3,6 +3,7 @@ use clap::{Parser, Subcommand};
 use indicatif::{ProgressBar, ProgressStyle};
 use ipnet::IpNet;
 use rayon::prelude::*;
+use std::io::{copy, Write};
 use std::path::Path;
 use std::process::exit;
 use std::sync::Arc;
@@ -397,39 +398,15 @@ fn main() {
                         for backup_to in &backup_destinations {
                             if let Some(backup_to) = backup_to.as_ref() {
                                 info!("writing additional backup trie to {}...", backup_to);
-                                match oneio::s3_url_parse(backup_to) {
-                                    Ok((bucket, key)) => {
-                                        if oneio::s3_env_check().is_err() {
-                                            error!(
-                                                "s3 environment variables not set, skipping backup to s3"
-                                            );
-                                        } else {
-                                            match oneio::s3_upload(&bucket, &key, rkyv_path.as_str()) {
-                                                Ok(_) => {
-                                                    info!("backup trie written to s3: {}", backup_to);
-                                                    to_send_heartbeat = true;
-                                                }
-                                                Err(e) => {
-                                                    error!(
-                                                        "failed to write backup trie to s3 {}: {}",
-                                                        backup_to, e
-                                                    );
-                                                }
-                                            }
-                                        }
+                                match backup_archive(&rkyv_path, backup_to) {
+                                    Ok(()) => {
+                                        info!("backup trie written to {}", backup_to);
+                                        to_send_heartbeat = true;
                                     }
-                                    Err(_) => match std::fs::copy(&rkyv_path, backup_to) {
-                                        Ok(_) => {
-                                            info!("backup trie written to disk: {}", backup_to);
-                                            to_send_heartbeat = true;
-                                        }
-                                        Err(e) => {
-                                            error!(
-                                                "failed to write backup trie to disk {}: {}",
-                                                backup_to, e
-                                            )
-                                        }
-                                    },
+                                    Err(e) => error!(
+                                        "failed to write backup trie to {}: {}",
+                                        backup_to, e
+                                    ),
                                 }
                             }
                         }
@@ -485,8 +462,6 @@ fn main() {
     }
 }
 
-use std::io::Write;
-
 fn get_tokio_runtime() -> tokio::runtime::Runtime {
     let blocking_cpus = num_threads();
     debug!("using {} cores for parsing html pages", blocking_cpus);
@@ -497,14 +472,81 @@ fn get_tokio_runtime() -> tokio::runtime::Runtime {
         .unwrap()
 }
 
+/// Stream a suffix-compressed source through oneio into an uncompressed local
+/// archive. The result is suitable for direct `mmap` access.
+fn download_rkyv_transport(url: &str, local_path: &str) -> anyhow::Result<()> {
+    let mut reader = oneio::get_reader(url)?;
+    let mut writer = std::fs::File::create(local_path)?;
+    copy(&mut reader, &mut writer)?;
+    writer.sync_all()?;
+    Ok(())
+}
+
+/// Create a gzip transport copy of a raw rkyv archive. The active archive is
+/// intentionally never gzip-compressed because rkyv serving requires mmap.
+fn create_rkyv_transport_gzip(source: &str) -> anyhow::Result<std::path::PathBuf> {
+    let temp = std::env::temp_dir().join(format!(
+        "wayback-rpki-{}-{}.rkyv.gz",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_nanos()
+    ));
+    let mut reader = std::fs::File::open(source)?;
+    let mut writer = oneio::get_writer(temp.to_str().unwrap())?;
+    copy(&mut reader, &mut writer)?;
+    writer.flush()?;
+    drop(writer);
+    Ok(temp)
+}
+
+/// Write an archive backup. A `.rkyv.gz` destination is explicitly a
+/// transport artifact; the running service continues to mmap the raw `.rkyv`.
+fn backup_archive(source: &str, destination: &str) -> anyhow::Result<()> {
+    let temporary = if destination.ends_with(".rkyv.gz") {
+        Some(create_rkyv_transport_gzip(source)?)
+    } else {
+        None
+    };
+    let upload_source = temporary
+        .as_ref()
+        .and_then(|p| p.to_str())
+        .unwrap_or(source);
+
+    let result = match oneio::s3_url_parse(destination) {
+        Ok((bucket, key)) => {
+            oneio::s3_env_check()?;
+            oneio::s3_upload(&bucket, &key, upload_source)?;
+            Ok(())
+        }
+        Err(_) => {
+            std::fs::copy(upload_source, destination)?;
+            Ok(())
+        }
+    };
+    if let Some(temp) = temporary {
+        let _ = std::fs::remove_file(temp);
+    }
+    result
+}
+
 /// Check if data file exists, and bootstrap if necessary
 fn check_bootstrap_and_download(path: &str, bootstrap: bool) {
     if !Path::new(path).exists() && bootstrap {
-        info!(
-            "downloading bootstrap file {} to {}",
-            REMOTE_BOOTSTRAP_URL, path
-        );
-        oneio::download(REMOTE_BOOTSTRAP_URL, path).unwrap();
+        if is_rkyv_path(path) {
+            info!(
+                "downloading compressed bootstrap {} and streaming it to raw mmap archive {}",
+                REMOTE_BOOTSTRAP_URL, path
+            );
+            download_rkyv_transport(REMOTE_BOOTSTRAP_URL, path).unwrap();
+        } else {
+            const LEGACY_BOOTSTRAP_URL: &str = "https://spaces.bgpkit.org/broker/roas_trie.bin.gz";
+            info!(
+                "downloading legacy bootstrap file {} to {}",
+                LEGACY_BOOTSTRAP_URL, path
+            );
+            oneio::download(LEGACY_BOOTSTRAP_URL, path).unwrap();
+        }
     }
 }
 
@@ -538,4 +580,61 @@ fn ensure_data_available(path: &str) {
         path
     );
     exit(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+
+    fn unique_path(suffix: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "wayback-rpki-main-test-{}-{}{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+            suffix
+        ))
+    }
+
+    #[test]
+    fn rkyv_gzip_backup_is_transport_only() {
+        let source = unique_path(".rkyv");
+        let backup = unique_path(".rkyv.gz");
+        let payload = b"raw rkyv archive bytes: must remain mmap-ready locally";
+        std::fs::write(&source, payload).unwrap();
+
+        backup_archive(source.to_str().unwrap(), backup.to_str().unwrap()).unwrap();
+        assert!(backup.exists());
+        assert_ne!(std::fs::read(&backup).unwrap(), payload);
+
+        let mut decoded = Vec::new();
+        oneio::get_reader(backup.to_str().unwrap())
+            .unwrap()
+            .read_to_end(&mut decoded)
+            .unwrap();
+        assert_eq!(decoded, payload);
+        assert_eq!(std::fs::read(&source).unwrap(), payload);
+
+        let _ = std::fs::remove_file(source);
+        let _ = std::fs::remove_file(backup);
+    }
+
+    #[test]
+    fn suffix_routing_and_sibling_discovery() {
+        assert!(is_rkyv_path("roas_trie.rkyv"));
+        assert!(!is_rkyv_path("roas_trie.bin.gz"));
+
+        let rkyv = unique_path(".rkyv");
+        let base = rkyv.to_str().unwrap().strip_suffix(".rkyv").unwrap();
+        let sibling = format!("{base}.bin.gz");
+        std::fs::write(&sibling, b"legacy").unwrap();
+        assert_eq!(
+            find_sibling_bin(rkyv.to_str().unwrap()),
+            Some(sibling.clone())
+        );
+        let _ = std::fs::remove_file(sibling);
+    }
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -8,17 +8,16 @@ use std::sync::Arc;
 use std::thread;
 use tabled::settings::Style;
 use tabled::Table;
-use tokio::runtime::Runtime;
 use tokio::sync::RwLock;
-use tracing::{debug, error, info, Level};
+use tracing::{debug, error, info, warn, Level};
 use wayback_rpki::*;
 
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 #[clap(name = "wayback-rpki")]
 struct Cli {
-    /// file path to dump the trie.
-    #[clap(default_value = "roas_trie.bin.gz", global = true)]
+    /// file path to the trie archive (v2 rkyv format).
+    #[clap(default_value = "roas_trie.rkyv", global = true)]
     path: String,
 
     /// download bootstrap file to help get started quickly
@@ -91,6 +90,13 @@ enum Opts {
         #[clap(short, long)]
         exact: Option<bool>,
     },
+    /// Convert a legacy v1 (bincode + ipnet-trie) archive to the v2 rkyv format
+    #[cfg(feature = "legacy")]
+    Convert {
+        /// path to the legacy v1 archive (e.g. roas_trie.bin.gz)
+        #[clap(short, long)]
+        from: String,
+    },
     /// Serve the API
     Serve {
         /// Additional path to backup the trie
@@ -102,7 +108,17 @@ enum Opts {
 
         #[clap(short, long, default_value = "40065")]
         port: u16,
+
+        /// update interval in seconds between data refreshes (default: 8 hours)
+        #[clap(short, long, default_value = "28800")]
+        update_interval: u64,
     },
+}
+
+fn num_threads() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4)
 }
 
 fn main() {
@@ -132,7 +148,6 @@ fn main() {
 
     let path = opts.path;
 
-    // check db url
     match opts.subcommands {
         Opts::Rebuild {
             tal,
@@ -140,14 +155,12 @@ fn main() {
             from,
             until,
         } => {
-            let chunks = chunks_opt.unwrap_or(num_cpus::get());
+            let chunks = chunks_opt.unwrap_or_else(num_threads);
             let all_files = get_tal_urls(tal)
                 .into_iter()
                 .flat_map(|tal_url| crawl_tal_after(tal_url.as_str(), from, until))
                 .collect::<Vec<RoaFile>>();
 
-            // conn.insert_roa_files(&all_files);
-            // let all_files = conn.get_all_files(tal.as_str(), false, latest);
             info!("total of {} roa files to process", all_files.len());
 
             let (sender_pb, receiver_pb) = std::sync::mpsc::sync_channel::<(String, i32)>(20);
@@ -167,10 +180,8 @@ fn main() {
 
             // dedicated thread for showing progress of the parsing
             thread::spawn(move || {
-                // let mut conn = DbConnection::new();
                 let mut writer = oneio::get_writer("wayback-rpki.bootstrap.log").unwrap();
                 for (url, _count) in receiver_pb.iter() {
-                    // conn.mark_file_as_processed(url.as_str(), true, count);
                     writeln!(writer, "{}", url).unwrap();
                     pb.set_message(url);
                     pb.inc(1);
@@ -179,12 +190,16 @@ fn main() {
 
             // dedicated writer thread
             let handle = thread::spawn(move || {
-                let mut trie = RoasTrie::new();
+                let mut trie = RoasTrieMut::new();
                 for entries in receiver_entries.iter() {
                     trie.process_entries(&entries, true);
                 }
-                trie.compress_dates();
                 trie.dump(path.as_str()).unwrap();
+                info!(
+                    "bootstrap finished: {} prefixes written to {}",
+                    trie.len(),
+                    path
+                );
             });
 
             all_files.par_chunks(chunks).for_each_with(
@@ -192,24 +207,27 @@ fn main() {
                 |(s_pb, s_entries), files| {
                     for file in files {
                         let url: &str = file.url.as_str();
-                        // info!("processing {}", url);
-                        if let Ok(roas) = parse_roas_csv(url) {
-                            let count = roas.len() as i32;
-                            s_entries.send(roas).unwrap();
-                            s_pb.send((url.to_owned(), count)).unwrap();
+                        match parse_roas_csv(url) {
+                            Ok(roas) => {
+                                let count = roas.len() as i32;
+                                s_entries.send(roas).unwrap();
+                                s_pb.send((url.to_owned(), count)).unwrap();
+                            }
+                            Err(e) => {
+                                warn!("failed to parse {}: {}", url, e);
+                                s_pb.send((url.to_owned(), 0)).unwrap();
+                            }
                         }
                     }
                 },
             );
 
             handle.join().unwrap();
-
-            info!("bootstrap finished");
         }
 
         Opts::Update { tal, until } => {
             check_bootstrap_and_download(path.as_str(), opts.bootstrap);
-            let mut trie = RoasTrie::load(path.as_str()).unwrap();
+            let mut trie = RoasTrieMut::load(path.as_str()).unwrap();
             trie.update(tal, until).unwrap();
             trie.dump(path.as_str()).unwrap();
         }
@@ -223,7 +241,7 @@ fn main() {
             exact,
         } => {
             check_bootstrap_and_download(path.as_str(), opts.bootstrap);
-            let trie = RoasTrie::load(path.as_str()).unwrap();
+            let trie = RoasTrie::open(path.as_str()).unwrap();
             let results: Vec<RoasLookupEntryTabled> = trie
                 .search(prefix, asn, max_len, date, current, exact.unwrap_or(true))
                 .into_iter()
@@ -234,15 +252,23 @@ fn main() {
 
         Opts::Fix {} => {
             check_bootstrap_and_download(path.as_str(), opts.bootstrap);
-            let mut trie = RoasTrie::load(path.as_str()).unwrap();
+            let mut trie = RoasTrieMut::load(path.as_str()).unwrap();
             trie.fill_gaps();
             trie.dump(path.as_str()).unwrap();
+        }
+
+        #[cfg(feature = "legacy")]
+        Opts::Convert { from } => {
+            let mut trie = wayback_rpki::legacy::load_legacy(&from).unwrap();
+            trie.dump(path.as_str()).unwrap();
+            info!("converted legacy archive {} -> {}", from, path);
         }
 
         Opts::Serve {
             backup_to,
             host,
             port,
+            update_interval,
         } => {
             let mut backup_destinations = vec![backup_to];
             if let Ok(p) = std::env::var("WAYBACK_BACKUP_TO") {
@@ -260,11 +286,9 @@ fn main() {
             }
 
             check_bootstrap_and_download(path.as_str(), opts.bootstrap);
-            let trie = RoasTrie::load(path.as_str()).unwrap();
+            let trie = RoasTrie::open(path.as_str()).unwrap();
             let trie_lock = Arc::new(RwLock::new(trie));
             let timer_lock = trie_lock.clone();
-
-            let update_interval = 60 * 60 * 8;
 
             thread::spawn(move || {
                 let rt = get_tokio_runtime();
@@ -274,28 +298,31 @@ fn main() {
                     loop {
                         interval.tick().await;
 
-                        info!("creating a backup trie...");
-                        // updating from the latest data available
-                        let read_lock = timer_lock.read().await;
-                        let mut backup = read_lock.clone();
-                        drop(read_lock);
+                        info!("updating trie from latest data...");
+                        // Load the current archive into a mutable trie, update, and
+                        // write back atomically. The serving trie itself stays
+                        // memory-mapped; only the updater materializes data.
+                        let mut backup = match RoasTrieMut::load(path.as_str()) {
+                            Ok(t) => t,
+                            Err(e) => {
+                                error!("failed to load trie for update: {}", e);
+                                continue;
+                            }
+                        };
                         if let Err(e) = backup.update(None, None) {
-                            error!("backup update failed: {}", e);
+                            error!("trie update failed: {}", e);
                             continue;
                         }
-
-                        info!("writing updated trie to disk...");
-                        match backup.dump(&path) {
-                            Ok(_) => {
-                                info!("backup trie written to disk: {}", path);
-                            }
-                            Err(e) => error!("failed to write backup trie to disk: {}", e),
+                        if let Err(e) = backup.dump(path.as_str()) {
+                            error!("failed to write updated trie to disk: {}", e);
+                            continue;
                         }
+                        info!("updated trie written to disk: {}", path);
 
                         let mut to_send_heartbeat = false;
                         for backup_to in &backup_destinations {
                             if let Some(backup_to) = backup_to.as_ref() {
-                                info!("writing additional backup trie to disk at {}...", backup_to);
+                                info!("writing additional backup trie to {}...", backup_to);
                                 match oneio::s3_url_parse(backup_to) {
                                     Ok((bucket, key)) => {
                                         if oneio::s3_env_check().is_err() {
@@ -306,22 +333,21 @@ fn main() {
                                                     info!("backup trie written to s3: {}", backup_to);
                                                     to_send_heartbeat = true;
                                                 }
-                                                Err(_) => {
-                                                    error!("failed to write backup trie to s3: {}", backup_to);
+                                                Err(e) => {
+                                                    error!("failed to write backup trie to s3 {}: {}", backup_to, e);
                                                 }
                                             }
                                         }
                                     }
                                     Err(_) => {
-                                        // not a s3 url, copy the current trie to the specified path
-                                        // make file system copy of the trie file at path
+                                        // not an s3 url: make a file system copy
                                         match std::fs::copy(&path, backup_to) {
                                             Ok(_) => {
                                                 info!("backup trie written to disk: {}", backup_to);
                                                 to_send_heartbeat = true;
                                             }
                                             Err(e) => {
-                                                error!("failed to write backup trie to disk: {}", e)
+                                                error!("failed to write backup trie to disk {}: {}", backup_to, e)
                                             }
                                         }
                                     }
@@ -332,16 +358,25 @@ fn main() {
                         if to_send_heartbeat {
                             if let Some(backup_heartbeat_url) = backup_heartbeat_url.as_ref() {
                                 info!("sending heartbeat to {}", backup_heartbeat_url);
-                                if let Err(e) = reqwest::blocking::get(backup_heartbeat_url) {
+                                if let Err(e) = oneio::read_to_string_lossy(backup_heartbeat_url) {
                                     error!("failed to send heartbeat: {}", e);
                                 }
                             }
                         }
 
-                        info!("replacing backup trie with the original trie...");
-                        let mut write_lock = timer_lock.write().await;
-                        write_lock.replace(backup);
-                        drop(write_lock);
+                        // Swap in the updated archive: re-map the file and replace.
+                        info!("swapping serving trie to updated archive...");
+                        match RoasTrie::open(path.as_str()) {
+                            Ok(new_trie) => {
+                                let mut write_lock = timer_lock.write().await;
+                                *write_lock = new_trie;
+                                drop(write_lock);
+                                info!("serving trie swapped");
+                            }
+                            Err(e) => {
+                                error!("failed to re-open updated trie: {}", e);
+                            }
+                        }
 
                         info!("wait for {} seconds before next update", update_interval);
                     }
@@ -349,7 +384,7 @@ fn main() {
             });
 
             tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(num_cpus::get())
+                .worker_threads(num_threads())
                 .enable_all()
                 .build()
                 .unwrap()
@@ -359,16 +394,16 @@ fn main() {
     }
 }
 
-fn get_tokio_runtime() -> Runtime {
-    let blocking_cpus = num_cpus::get();
+use std::io::Write;
 
+fn get_tokio_runtime() -> tokio::runtime::Runtime {
+    let blocking_cpus = num_threads();
     debug!("using {} cores for parsing html pages", blocking_cpus);
-    let rt = tokio::runtime::Builder::new_multi_thread()
+    tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .max_blocking_threads(blocking_cpus)
         .build()
-        .unwrap();
-    rt
+        .unwrap()
 }
 
 /// Check if data file exists, and bootstrap if necessary
@@ -377,12 +412,11 @@ fn check_bootstrap_and_download(path: &str, bootstrap: bool) {
         // if file at `path` does not exist
         if bootstrap {
             // download bootstrap file
-            let remote_bootstrap_file = "https://spaces.bgpkit.org/broker/roas_trie.bin.gz";
             info!(
                 "downloading bootstrap file {} to {}",
-                remote_bootstrap_file, path
+                REMOTE_BOOTSTRAP_URL, path
             );
-            oneio::download(remote_bootstrap_file, path, None).unwrap();
+            oneio::download(REMOTE_BOOTSTRAP_URL, path).unwrap();
         }
     }
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -535,6 +535,8 @@ fn backup_archive(source: &str, destination: &str) -> anyhow::Result<()> {
 /// For a missing `.rkyv`, a local sibling legacy archive is always preferred:
 /// `roas_trie.bin.gz`/`.bin` is converted before attempting network bootstrap.
 fn check_bootstrap_and_download(path: &str, bootstrap: bool) {
+    const LEGACY_BOOTSTRAP_URL: &str = "https://spaces.bgpkit.org/broker/roas_trie.bin.gz";
+
     if Path::new(path).exists() {
         return;
     }
@@ -556,12 +558,34 @@ fn check_bootstrap_and_download(path: &str, bootstrap: bool) {
 
     if is_rkyv_path(path) {
         info!(
-            "no local legacy archive found; downloading compressed bootstrap {} and streaming it to raw mmap archive {}",
-            REMOTE_BOOTSTRAP_URL, path
+            "no local legacy archive found; attempting compressed rkyv bootstrap {}",
+            REMOTE_BOOTSTRAP_URL
         );
-        download_rkyv_transport(REMOTE_BOOTSTRAP_URL, path).unwrap();
+        if let Err(rkyv_error) = download_rkyv_transport(REMOTE_BOOTSTRAP_URL, path) {
+            // During the transition the v1 archive remains the durable remote
+            // bootstrap source. Download it beside the requested rkyv path, then
+            // reuse the normal conversion path to create the mmap-ready archive.
+            let legacy_path = format!("{}.bin.gz", path.strip_suffix(".rkyv").unwrap_or(path));
+            warn!(
+                "rkyv bootstrap {} failed: {}; falling back to legacy bootstrap {}",
+                REMOTE_BOOTSTRAP_URL, rkyv_error, LEGACY_BOOTSTRAP_URL
+            );
+            if let Err(legacy_error) = oneio::download(LEGACY_BOOTSTRAP_URL, &legacy_path) {
+                error!(
+                    "legacy bootstrap {} also failed: {}",
+                    LEGACY_BOOTSTRAP_URL, legacy_error
+                );
+                exit(1);
+            }
+            if let Err(convert_error) = auto_convert(&legacy_path, path) {
+                error!(
+                    "failed to convert downloaded legacy bootstrap {}: {}",
+                    legacy_path, convert_error
+                );
+                exit(1);
+            }
+        }
     } else {
-        const LEGACY_BOOTSTRAP_URL: &str = "https://spaces.bgpkit.org/broker/roas_trie.bin.gz";
         info!(
             "downloading legacy bootstrap file {} to {}",
             LEGACY_BOOTSTRAP_URL, path

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -106,7 +106,7 @@ enum Opts {
         #[clap(long)]
         backup_to: Option<String>,
 
-        #[clap(short, long, default_value = "0.0.0.0")]
+        #[clap(short = 'H', long, default_value = "0.0.0.0")]
         host: String,
 
         #[clap(short, long, default_value = "40065")]
@@ -530,23 +530,43 @@ fn backup_archive(source: &str, destination: &str) -> anyhow::Result<()> {
     result
 }
 
-/// Check if data file exists, and bootstrap if necessary
+/// Ensure a requested archive is present.
+///
+/// For a missing `.rkyv`, a local sibling legacy archive is always preferred:
+/// `roas_trie.bin.gz`/`.bin` is converted before attempting network bootstrap.
 fn check_bootstrap_and_download(path: &str, bootstrap: bool) {
-    if !Path::new(path).exists() && bootstrap {
-        if is_rkyv_path(path) {
+    if Path::new(path).exists() {
+        return;
+    }
+
+    if is_rkyv_path(path) {
+        if let Some(bin_path) = find_sibling_bin(path) {
             info!(
-                "downloading compressed bootstrap {} and streaming it to raw mmap archive {}",
-                REMOTE_BOOTSTRAP_URL, path
+                "requested {} not found; auto-converting local sibling {} before bootstrap",
+                path, bin_path
             );
-            download_rkyv_transport(REMOTE_BOOTSTRAP_URL, path).unwrap();
-        } else {
-            const LEGACY_BOOTSTRAP_URL: &str = "https://spaces.bgpkit.org/broker/roas_trie.bin.gz";
-            info!(
-                "downloading legacy bootstrap file {} to {}",
-                LEGACY_BOOTSTRAP_URL, path
-            );
-            oneio::download(LEGACY_BOOTSTRAP_URL, path).unwrap();
+            auto_convert(&bin_path, path).unwrap();
+            return;
         }
+    }
+
+    if !bootstrap {
+        return;
+    }
+
+    if is_rkyv_path(path) {
+        info!(
+            "no local legacy archive found; downloading compressed bootstrap {} and streaming it to raw mmap archive {}",
+            REMOTE_BOOTSTRAP_URL, path
+        );
+        download_rkyv_transport(REMOTE_BOOTSTRAP_URL, path).unwrap();
+    } else {
+        const LEGACY_BOOTSTRAP_URL: &str = "https://spaces.bgpkit.org/broker/roas_trie.bin.gz";
+        info!(
+            "downloading legacy bootstrap file {} to {}",
+            LEGACY_BOOTSTRAP_URL, path
+        );
+        oneio::download(LEGACY_BOOTSTRAP_URL, path).unwrap();
     }
 }
 

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -1,0 +1,46 @@
+//! Legacy v1 archive import (bincode + ipnet-trie).
+//!
+//! Only compiled with the `legacy` feature. Used by the `convert` subcommand
+//! for one-time migration of old `roas_trie.bin.gz` archives to the v2 format.
+
+use crate::{RoaRecordMut, RoasTrieMut};
+use anyhow::Result;
+use bincode::{Decode, Encode};
+use ipnet_trie::IpnetTrie;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::io::Read;
+
+#[derive(Debug, Clone, Eq, PartialEq, Encode, Decode)]
+struct LegacyRoasTrieEntry {
+    max_len: u8,
+    origin: u32,
+    dates: HashSet<i64>,
+    dates_compressed: VecDeque<(i64, i64)>,
+}
+
+/// Load a v1 (bincode + ipnet-trie) archive into a mutable v2 trie builder.
+pub fn load_legacy(path: &str) -> Result<RoasTrieMut> {
+    let mut bytes = Vec::new();
+    oneio::get_reader(path)?.read_to_end(&mut bytes)?;
+    let mut trie: IpnetTrie<HashMap<(u8, u32), LegacyRoasTrieEntry>> = IpnetTrie::new();
+    trie.import_from_reader(&mut bytes.as_slice())?;
+
+    let mut out = RoasTrieMut::new();
+    let mut latest: i64 = 0;
+    for (prefix, map) in trie.iter() {
+        for entry in map.values() {
+            let mut rec = RoaRecordMut::new_legacy(entry.max_len, entry.origin);
+            rec.dates.extend(entry.dates.iter().copied());
+            rec.ranges.extend(entry.dates_compressed.iter().copied());
+            if let Some(d) = entry.dates.iter().max() {
+                latest = latest.max(*d);
+            }
+            if let Some((_, end)) = entry.dates_compressed.back() {
+                latest = latest.max(*end);
+            }
+            out.insert_record(prefix, rec);
+        }
+    }
+    out.set_latest_date(latest);
+    Ok(out)
+}

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -1,46 +1,619 @@
-//! Legacy v1 archive import (bincode + ipnet-trie).
+//! Legacy v1 archive support (bincode + ipnet-trie).
 //!
-//! Only compiled with the `legacy` feature. Used by the `convert` subcommand
-//! for one-time migration of old `roas_trie.bin.gz` archives to the v2 format.
+//! Users pointing at a `.bin`/`.bin.gz` data file are routed to this
+//! in-memory implementation, preserving v1 behavior. `convert` uses
+//! [`LegacyRoasTrie::load`] followed by conversion to the v2 builder.
 
-use crate::{RoaRecordMut, RoasTrieMut};
+use crate::roas_trie::KNOWN_GAPS_STR;
+use crate::{
+    crawl_tal_after, get_tal_urls, parse_roas_csv, RoaEntry, RoaFile, RoaRecordMut,
+    RoasLookupEntry, RoasTrieMut, RpkiValidation,
+};
 use anyhow::Result;
 use bincode::{Decode, Encode};
+use chrono::NaiveDate;
+use ipnet::IpNet;
 use ipnet_trie::IpnetTrie;
+use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::io::Read;
+use tracing::info;
+
+/// Type alias for trie entries keyed by (max_len, origin).
+type RoasTrieMap = HashMap<(u8, u32), LegacyRoasTrieEntry>;
+
+#[derive(Clone)]
+pub struct LegacyRoasTrie {
+    pub(crate) trie: IpnetTrie<HashMap<(u8, u32), LegacyRoasTrieEntry>>,
+    pub(crate) latest_date: i64,
+}
 
 #[derive(Debug, Clone, Eq, PartialEq, Encode, Decode)]
-struct LegacyRoasTrieEntry {
+pub struct LegacyRoasTrieEntry {
+    /// ROA max length
     max_len: u8,
+    /// Prefix origin
     origin: u32,
+    /// Uncompressed dates stored in HashSet
     dates: HashSet<i64>,
+    /// Compressed dates stored in VecDeque, each tuple represents a date range
     dates_compressed: VecDeque<(i64, i64)>,
 }
 
-/// Load a v1 (bincode + ipnet-trie) archive into a mutable v2 trie builder.
-pub fn load_legacy(path: &str) -> Result<RoasTrieMut> {
-    let mut bytes = Vec::new();
-    oneio::get_reader(path)?.read_to_end(&mut bytes)?;
-    let mut trie: IpnetTrie<HashMap<(u8, u32), LegacyRoasTrieEntry>> = IpnetTrie::new();
-    trie.import_from_reader(&mut bytes.as_slice())?;
+impl LegacyRoasTrieEntry {
+    pub fn new(date_ts: i64, max_len: u8, origin: u32, bootstrap: bool) -> LegacyRoasTrieEntry {
+        match bootstrap {
+            true => LegacyRoasTrieEntry {
+                max_len,
+                origin,
+                dates: HashSet::from([date_ts]),
+                dates_compressed: VecDeque::new(),
+            },
 
-    let mut out = RoasTrieMut::new();
-    let mut latest: i64 = 0;
-    for (prefix, map) in trie.iter() {
-        for entry in map.values() {
-            let mut rec = RoaRecordMut::new_legacy(entry.max_len, entry.origin);
-            rec.dates.extend(entry.dates.iter().copied());
-            rec.ranges.extend(entry.dates_compressed.iter().copied());
-            if let Some(d) = entry.dates.iter().max() {
-                latest = latest.max(*d);
-            }
-            if let Some((_, end)) = entry.dates_compressed.back() {
-                latest = latest.max(*end);
-            }
-            out.insert_record(prefix, rec);
+            false => LegacyRoasTrieEntry {
+                max_len,
+                origin,
+                dates: HashSet::new(),
+                dates_compressed: VecDeque::from([(date_ts, date_ts)]),
+            },
         }
     }
-    out.set_latest_date(latest);
-    Ok(out)
+
+    /// Do full compression where we explode the dates_compressed into individual dates and
+    /// then compress them again with the new dates
+    pub fn full_compress(&mut self) {
+        let mut dates = self.dates.iter().copied().collect::<Vec<i64>>();
+        self.dates.clear();
+
+        // explode the dates_compressed into individual dates
+        for (start, end) in self.dates_compressed.iter() {
+            let mut date = *start;
+            while date <= *end {
+                dates.push(date);
+                date += chrono::Duration::days(1).num_seconds();
+            }
+        }
+
+        // sort the dates
+        dates.sort();
+
+        // compress the dates
+        let mut compressed = VecDeque::new();
+        let mut start = dates[0];
+        let mut end = dates[0];
+        for d in dates.iter().skip(1) {
+            if *d == end + chrono::Duration::days(1).num_seconds() {
+                end = *d;
+            } else {
+                compressed.push_back((start, end));
+                start = *d;
+                end = *d;
+            }
+        }
+        compressed.push_back((start, end));
+
+        self.dates_compressed = compressed;
+
+        // after the full compression, the dates HashSet should be empty
+        assert!(self.dates.is_empty());
+    }
+
+    /// Push a new date: if bootstrap is true, push to hashSet, otherwise push to VecDeque
+    pub fn push_date(&mut self, date_ts: i64, bootstrap: bool) {
+        match bootstrap {
+            true => {
+                self.dates.insert(date_ts);
+            }
+            false => {
+                if self.dates_compressed.is_empty() {
+                    self.dates_compressed.push_back((date_ts, date_ts));
+                } else {
+                    let (_start, end) = self.dates_compressed.back_mut().unwrap();
+                    let next_day_ts = *end + chrono::Duration::days(1).num_seconds();
+
+                    match date_ts.cmp(&next_day_ts) {
+                        Ordering::Equal => {
+                            *end = date_ts;
+                        }
+                        Ordering::Greater => {
+                            self.dates_compressed.push_back((date_ts, date_ts));
+                        }
+                        Ordering::Less => {
+                            // the date is already in the range or in the past, skip
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn contains_date(&self, date_ts: i64) -> bool {
+        self.dates.contains(&date_ts)
+            || self
+                .dates_compressed
+                .iter()
+                .any(|(start, end)| date_ts >= *start && date_ts <= *end)
+    }
+}
+
+impl LegacyRoasTrieEntry {
+    fn convert_to_hash_map(self) -> HashMap<(u8, u32), LegacyRoasTrieEntry> {
+        HashMap::from([((self.max_len, self.origin), self)])
+    }
+}
+
+impl Default for LegacyRoasTrie {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LegacyRoasTrie {
+    pub fn new() -> LegacyRoasTrie {
+        LegacyRoasTrie {
+            trie: IpnetTrie::new(),
+            latest_date: 0,
+        }
+    }
+
+    pub fn load(path: &str) -> Result<LegacyRoasTrie> {
+        info!("loading trie from {} ...", path);
+        let mut reader = oneio::get_reader(path)?;
+        let mut trie: IpnetTrie<HashMap<(u8, u32), LegacyRoasTrieEntry>> = IpnetTrie::new();
+        trie.import_from_reader(&mut reader)?;
+        let mut roas_trie = LegacyRoasTrie {
+            trie,
+            latest_date: 0,
+        };
+        roas_trie.update_latest_date();
+        Ok(roas_trie)
+    }
+
+    pub fn fill_gaps(&mut self) {
+        info!("filling known gaps...");
+        const ONE_DAY_SECONDS: i64 = 86400;
+
+        for (start, end) in KNOWN_GAPS_STR.iter() {
+            let start_ts = chrono::NaiveDate::parse_from_str(start, "%Y-%m-%d")
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap()
+                .and_utc()
+                .timestamp();
+            let end_ts = chrono::NaiveDate::parse_from_str(end, "%Y-%m-%d")
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap()
+                .and_utc()
+                .timestamp();
+
+            // vector of timestamps from start_ts to end_ts
+            let mut dates = Vec::new();
+            let mut date = start_ts;
+            while date <= end_ts {
+                dates.push(date);
+                date += ONE_DAY_SECONDS;
+            }
+
+            for (_prefix, map) in self.trie.iter_mut() {
+                for entry in map.values_mut() {
+                    let mut should_compress = false;
+                    for i in 0..entry.dates_compressed.len() - 1 {
+                        // let (start, end) = entry.dates_compressed[i];
+                        if start_ts - ONE_DAY_SECONDS == entry.dates_compressed[i].1
+                            && end_ts + ONE_DAY_SECONDS == entry.dates_compressed[i + 1].0
+                        {
+                            entry.dates.extend(&dates);
+                            should_compress = true;
+                        }
+                    }
+                    if should_compress {
+                        entry.full_compress();
+                    }
+                }
+            }
+        }
+        info!("filling known gaps... done");
+    }
+
+    fn update_latest_date(&mut self) {
+        let mut latest_date = 0;
+        for (_prefix, map) in self.trie.iter() {
+            for entry in map.values() {
+                if let Some(date) = entry.dates.iter().max() {
+                    if *date > latest_date {
+                        latest_date = *date;
+                    }
+                }
+                if let Some((_, end)) = entry.dates_compressed.back() {
+                    if *end > latest_date {
+                        latest_date = *end;
+                    }
+                }
+            }
+        }
+        self.latest_date = latest_date;
+        info!("updating latest date to {}", self.get_latest_date());
+    }
+
+    pub fn dump(&self, path: &str) -> Result<()> {
+        info!("exporting trie to {} ...", path);
+        let mut writer = oneio::get_writer(path)?;
+        self.trie.export_to_writer(&mut writer)?;
+        Ok(())
+    }
+
+    pub fn process_csv(&mut self, path: &str, bootstrap: bool) -> Result<()> {
+        let entries = parse_roas_csv(path)?;
+        self.process_entries(&entries, bootstrap);
+        Ok(())
+    }
+
+    pub fn process_entries(&mut self, entries: &Vec<RoaEntry>, bootstrap: bool) {
+        for entry in entries {
+            let prefix = entry.prefix;
+            let max_len = entry.max_len as u8;
+            let origin = entry.asn;
+            let date_ts = entry
+                .date
+                .and_time(chrono::NaiveTime::from_hms_opt(0, 0, 0).unwrap())
+                .and_utc()
+                .timestamp();
+
+            match self.trie.exact_match_mut(prefix) {
+                Some(v) => {
+                    v.entry((max_len, origin))
+                        .and_modify(|e| e.push_date(date_ts, bootstrap))
+                        .or_insert_with(|| {
+                            LegacyRoasTrieEntry::new(date_ts, max_len, origin, bootstrap)
+                        });
+                }
+                None => {
+                    self.trie.insert(
+                        prefix,
+                        LegacyRoasTrieEntry::new(date_ts, max_len, origin, bootstrap)
+                            .convert_to_hash_map(),
+                    );
+                }
+            };
+
+            if date_ts > self.latest_date {
+                self.latest_date = date_ts;
+            }
+        }
+    }
+
+    pub fn get_latest_date(&self) -> NaiveDate {
+        chrono::DateTime::from_timestamp(self.latest_date, 0)
+            .unwrap()
+            .naive_utc()
+            .date()
+    }
+
+    pub fn compress_dates(&mut self) {
+        info!("compressing dates into date ranges...");
+        for (_prefix, map) in self.trie.iter_mut() {
+            for entry in map.values_mut() {
+                entry.full_compress();
+            }
+        }
+    }
+
+    pub fn validate(&self, prefix: &IpNet, origin: u32, date_ts: i64) -> RpkiValidation {
+        let mut is_valid = RpkiValidation::Unknown;
+        'outer: for matched in self.trie.matches(prefix) {
+            for entry in matched.1.values() {
+                if entry.origin == origin
+                    && entry.max_len >= prefix.prefix_len()
+                    && entry.contains_date(date_ts)
+                {
+                    is_valid = RpkiValidation::Valid;
+                    break 'outer;
+                }
+            }
+            is_valid = RpkiValidation::Invalid;
+        }
+
+        is_valid
+    }
+
+    pub fn lookup_prefix(&self, prefix: &IpNet) -> Vec<RoasLookupEntry> {
+        let mut entries = Vec::new();
+        for (prefix, map) in self.trie.matches(prefix) {
+            for entry in map.values() {
+                entries.push(RoasLookupEntry {
+                    prefix,
+                    origin: entry.origin,
+                    max_len: entry.max_len,
+                    dates_ranges: entry
+                        .dates_compressed
+                        .iter()
+                        .map(|(start, end)| {
+                            (
+                                chrono::DateTime::from_timestamp(*start, 0)
+                                    .unwrap()
+                                    .naive_utc()
+                                    .date(),
+                                chrono::DateTime::from_timestamp(*end, 0)
+                                    .unwrap()
+                                    .naive_utc()
+                                    .date(),
+                            )
+                        })
+                        .collect(),
+                });
+            }
+        }
+        entries
+    }
+
+    pub fn search(
+        &self,
+        prefix: Option<IpNet>,
+        origin: Option<u32>,
+        max_len: Option<u8>,
+        date: Option<NaiveDate>,
+        current: Option<bool>,
+        exact: bool,
+    ) -> Vec<RoasLookupEntry> {
+        let mut entries = Vec::new();
+
+        // prefix filter: exact match by default (fixes issue #9),
+        // falls back to matches() when exact=false for supernet/subnet inclusion
+        let iter: Vec<(IpNet, &RoasTrieMap)> = match prefix {
+            Some(prefix) if exact => match self.trie.exact_match(prefix) {
+                Some(map) => vec![(prefix, map)],
+                None => vec![],
+            },
+            Some(prefix) => self.trie.matches(&prefix),
+            None => self.trie.iter().collect(),
+        };
+
+        let mut only_expired = false;
+
+        let date = match current {
+            Some(c) => match c {
+                true => Some(self.latest_date),
+                false => {
+                    only_expired = true;
+                    None
+                }
+            },
+            None => date.map(|d| {
+                d.and_time(chrono::NaiveTime::from_hms_opt(0, 0, 0).unwrap())
+                    .and_utc()
+                    .timestamp()
+            }),
+        };
+
+        for (prefix, map) in iter {
+            for entry in map.values() {
+                if let Some(origin) = origin {
+                    if entry.origin != origin {
+                        continue;
+                    }
+                }
+
+                if let Some(max_len) = max_len {
+                    if entry.max_len != max_len {
+                        continue;
+                    }
+                }
+
+                if let Some(date) = date {
+                    // check if date_ts is within one of the date ranges in entry.dates_compressed
+                    if entry
+                        .dates_compressed
+                        .iter()
+                        .all(|(start, end)| date < *start || date > *end)
+                    {
+                        continue;
+                    }
+                }
+
+                if only_expired
+                    && entry
+                        .dates_compressed
+                        .iter()
+                        .any(|(_, end)| *end >= self.latest_date)
+                {
+                    // if any of the date ranges is still current, the entry is current, skip
+                    continue;
+                }
+
+                entries.push(RoasLookupEntry {
+                    prefix,
+                    origin: entry.origin,
+                    max_len: entry.max_len,
+                    dates_ranges: entry
+                        .dates_compressed
+                        .iter()
+                        .map(|(start, end)| {
+                            (
+                                chrono::DateTime::from_timestamp(*start, 0)
+                                    .unwrap()
+                                    .naive_utc()
+                                    .date(),
+                                chrono::DateTime::from_timestamp(*end, 0)
+                                    .unwrap()
+                                    .naive_utc()
+                                    .date(),
+                            )
+                        })
+                        .collect(),
+                });
+            }
+        }
+        entries
+    }
+
+    pub fn update(&mut self, tal: Option<String>, until: Option<NaiveDate>) -> Result<()> {
+        info!("updating trie... tal: {:?}, until: {:?}", &tal, &until);
+        let mut all_files = get_tal_urls(tal)
+            .into_iter()
+            .flat_map(|tal_url| {
+                crawl_tal_after(
+                    tal_url.as_str(),
+                    Some(self.get_latest_date() + chrono::Duration::days(1)),
+                    until,
+                )
+            })
+            .collect::<Vec<RoaFile>>();
+
+        if all_files.is_empty() {
+            info!("trie is up to date. No new files found.");
+            return Ok(());
+        }
+
+        // sort by date
+        all_files.sort_by_key(|a| a.file_date);
+
+        for file in all_files {
+            info!("processing {}", file.url.as_str());
+            let url: &str = file.url.as_str();
+            if let Ok(roas) = parse_roas_csv(url) {
+                self.process_entries(&roas, false);
+            }
+        }
+
+        info!("updating trie... done");
+        Ok(())
+    }
+
+    pub fn replace(&mut self, other: LegacyRoasTrie) {
+        self.trie = other.trie;
+        self.latest_date = other.latest_date;
+    }
+
+    /// Convert the v1 in-memory trie into a v2 [`RoasTrieMut`] builder,
+    /// preserving all prefix/origin/max_len/date-range data.
+    ///
+    /// This is used by:
+    /// - the `convert` subcommand
+    /// - automatic on-the-fly conversion when a `.rkyv` file is missing but a
+    ///   sibling `.bin`/`.bin.gz` file exists
+    pub fn to_builder(&self) -> RoasTrieMut {
+        let mut builder = RoasTrieMut::new();
+        for (prefix, entries) in self.trie.iter() {
+            for ((max_len, origin), entry) in entries.iter() {
+                // Collect all date ranges (both uncompressed HashSet and compressed VecDeque)
+                let mut all_dates: Vec<i64> = entry.dates.iter().copied().collect();
+                for (start, end) in entry.dates_compressed.iter() {
+                    let mut d = *start;
+                    while d <= *end {
+                        all_dates.push(d);
+                        d += chrono::Duration::days(1).num_seconds();
+                    }
+                }
+                all_dates.sort();
+                all_dates.dedup();
+
+                // Build ranges from sorted dates
+                let mut ranges = Vec::new();
+                if !all_dates.is_empty() {
+                    let mut range_start = all_dates[0];
+                    let mut range_end = all_dates[0];
+                    for &d in &all_dates[1..] {
+                        if d == range_end + chrono::Duration::days(1).num_seconds() {
+                            range_end = d;
+                        } else {
+                            ranges.push((range_start, range_end));
+                            range_start = d;
+                            range_end = d;
+                        }
+                    }
+                    ranges.push((range_start, range_end));
+                }
+
+                let record = RoaRecordMut {
+                    origin: *origin,
+                    max_len: *max_len,
+                    dates: HashSet::new(),
+                    ranges,
+                };
+                builder.insert_record(prefix, record);
+            }
+        }
+        builder.set_latest_date(self.latest_date);
+        builder
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RoaEntry;
+    use chrono::NaiveDate;
+    use ipnet::IpNet;
+    use std::net::Ipv4Addr;
+    use std::str::FromStr;
+
+    fn make_entry(prefix: &str, asn: u32, max_len: i32, date: NaiveDate) -> RoaEntry {
+        RoaEntry {
+            tal: "test".to_string(),
+            prefix: IpNet::from_str(prefix).unwrap(),
+            max_len,
+            asn,
+            date,
+        }
+    }
+
+    fn build_test_trie() -> LegacyRoasTrie {
+        let date = NaiveDate::from_ymd_opt(2024, 1, 1).unwrap();
+        let entries = vec![
+            // supernet
+            make_entry("1.0.0.0/8", 64512, 8, date),
+            // exact prefix we will search for
+            make_entry("1.1.1.0/24", 13335, 24, date),
+            // subnet (more-specific)
+            make_entry("1.1.1.0/25", 64513, 25, date),
+        ];
+        let mut trie = LegacyRoasTrie::new();
+        trie.process_entries(&entries, true);
+        trie.compress_dates();
+        trie
+    }
+
+    #[test]
+    fn test_search_exact_returns_only_matching_prefix() {
+        let trie = build_test_trie();
+        let prefix = IpNet::V4(ipnet::Ipv4Net::new(Ipv4Addr::new(1, 1, 1, 0), 24).unwrap());
+
+        // exact=true should return only the /24 ROA
+        let results = trie.search(Some(prefix), None, None, None, None, true);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].prefix.to_string(), "1.1.1.0/24");
+        assert_eq!(results[0].origin, 13335);
+    }
+
+    #[test]
+    fn test_search_non_exact_includes_super_and_sub() {
+        let trie = build_test_trie();
+        let prefix = IpNet::V4(ipnet::Ipv4Net::new(Ipv4Addr::new(1, 1, 1, 0), 24).unwrap());
+
+        // exact=false should use matches(), which includes the supernet and subnet
+        let results = trie.search(Some(prefix), None, None, None, None, false);
+        let prefixes: Vec<String> = results.iter().map(|r| r.prefix.to_string()).collect();
+        assert!(prefixes.contains(&"1.0.0.0/8".to_string()));
+        assert!(prefixes.contains(&"1.1.1.0/24".to_string()));
+        assert!(prefixes.contains(&"1.1.1.0/25".to_string()));
+    }
+
+    #[test]
+    fn test_search_exact_no_match_returns_empty() {
+        let trie = build_test_trie();
+        // prefix not in trie
+        let prefix = IpNet::V4(ipnet::Ipv4Net::new(Ipv4Addr::new(2, 2, 2, 0), 24).unwrap());
+
+        let results = trie.search(Some(prefix), None, None, None, None, true);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_search_no_prefix_returns_all() {
+        let trie = build_test_trie();
+
+        // No prefix filter → return all entries regardless of exact flag
+        let results = trie.search(None, None, None, None, None, true);
+        assert_eq!(results.len(), 3);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::nonminimal_bool)]
 
-mod api;
-#[cfg(feature = "legacy")]
+pub mod api;
 pub mod legacy;
 mod roas_trie;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,9 @@
 #![allow(clippy::nonminimal_bool)]
 
-// pub mod roas_table;
 mod api;
+#[cfg(feature = "legacy")]
+pub mod legacy;
 mod roas_trie;
-
-// pub use crate::roas_table::*;
 
 use anyhow::{anyhow, Result};
 use chrono::{Datelike, NaiveDate};
@@ -40,7 +39,7 @@ fn __crawl_years(tal_url: &str) -> Vec<String> {
     let year_pattern: Regex = Regex::new(r#"<a href=".*">\s*(\d\d\d\d)/</a>.*"#).unwrap();
 
     // get all years
-    let body = match oneio::read_to_string(tal_url) {
+    let body = match oneio::read_to_string_lossy(tal_url) {
         Ok(b) => b,
         Err(e) => {
             warn!("failed to fetch years listing {}: {}", tal_url, e);
@@ -58,7 +57,7 @@ fn __crawl_years(tal_url: &str) -> Vec<String> {
 fn __crawl_months_days(months_days_url: &str) -> Vec<String> {
     let month_day_pattern: Regex = Regex::new(r#"<a href=".*">\s*(\d\d)/</a>.*"#).unwrap();
 
-    let body = match oneio::read_to_string(months_days_url) {
+    let body = match oneio::read_to_string_lossy(months_days_url) {
         Ok(b) => b,
         Err(e) => {
             warn!(
@@ -191,7 +190,7 @@ pub fn parse_roas_csv(csv_url: &str) -> Result<Vec<RoaEntry>> {
 
     let mut file_ok = false;
 
-    for line in oneio::read_lines(csv_url)? {
+    for line in oneio::read_lines_lossy(csv_url)? {
         let line = line.unwrap();
 
         if line.starts_with("URI") {

--- a/src/roas_trie.rs
+++ b/src/roas_trie.rs
@@ -13,8 +13,9 @@ use tracing::{info, warn};
 /// On-disk format version. v2: rkyv archive of [`RoasTrieData`].
 pub const FORMAT_VERSION: u32 = 2;
 
-/// Default remote bootstrap archive URL (v2 rkyv format).
-pub const REMOTE_BOOTSTRAP_URL: &str = "https://spaces.bgpkit.org/broker/roas_trie.rkyv";
+/// Default remote bootstrap archive URL. This is gzip-compressed for transport;
+/// the client streams it into a raw local `.rkyv` file for mmap serving.
+pub const REMOTE_BOOTSTRAP_URL: &str = "https://spaces.bgpkit.org/broker/roas_trie.rkyv.gz";
 
 pub(crate) const KNOWN_GAPS_STR: [(&str, &str); 24] = [
     ("2018-12-28", "2019-01-02"),

--- a/src/roas_trie.rs
+++ b/src/roas_trie.rs
@@ -1,18 +1,22 @@
 use crate::{crawl_tal_after, get_tal_urls, parse_roas_csv, RoaEntry, RoaFile};
-use anyhow::Result;
-use bincode::{Decode, Encode};
+use anyhow::{anyhow, Result};
 use chrono::NaiveDate;
 use ipnet::IpNet;
-use ipnet_trie::IpnetTrie;
-use std::cmp::Ordering;
-use std::collections::{HashMap, HashSet, VecDeque};
+use prefix_trie::joint::JointPrefixMap;
+use prefix_trie::{AsView, TrieView};
+use rkyv::{Archive, Deserialize, Serialize};
+use std::collections::HashSet;
+use std::io::Read;
 use tabled::Tabled;
-use tracing::info;
+use tracing::{info, warn};
 
-/// Type alias for trie entries keyed by (max_len, origin).
-type RoasTrieMap = HashMap<(u8, u32), RoasTrieEntry>;
+/// On-disk format version. v2: rkyv archive of [`RoasTrieData`].
+pub const FORMAT_VERSION: u32 = 2;
 
-const KNOWN_GAPS_STR: [(&str, &str); 25] = [
+/// Default remote bootstrap archive URL (v2 rkyv format).
+pub const REMOTE_BOOTSTRAP_URL: &str = "https://spaces.bgpkit.org/broker/roas_trie.rkyv";
+
+const KNOWN_GAPS_STR: [(&str, &str); 24] = [
     ("2018-12-28", "2019-01-02"),
     ("2019-10-22", "2019-10-22"),
     ("2019-11-24", "2019-11-24"),
@@ -37,25 +41,125 @@ const KNOWN_GAPS_STR: [(&str, &str); 25] = [
     ("2022-02-16", "2022-02-16"),
     ("2023-06-24", "2023-06-24"),
     ("2023-07-14", "2023-07-17"),
-    ("2023-06-24", "2023-06-24"),
 ];
 
-#[derive(Clone)]
-pub struct RoasTrie {
-    pub trie: IpnetTrie<HashMap<(u8, u32), RoasTrieEntry>>,
-    pub latest_date: i64,
+const ONE_DAY_SECONDS: i64 = 86400;
+
+/// A single ROA record in the serialized archive: one (max_len, origin) pair
+/// with its compressed date ranges.
+#[derive(Debug, Clone, Archive, Serialize, Deserialize)]
+pub struct RoaRecord {
+    /// ROA max length
+    pub max_len: u8,
+    /// ROA origin ASN
+    pub origin: u32,
+    /// Compressed date ranges, each tuple is (start_ts, end_ts), UTC day granularity.
+    pub dates: Vec<(i64, i64)>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Encode, Decode)]
-pub struct RoasTrieEntry {
-    /// ROA max length
-    max_len: u8,
-    /// Prefix origin
-    origin: u32,
-    /// Uncompressed dates stored in HashSet
-    dates: HashSet<i64>,
-    /// Compressed dates stored in VecDeque, each tuple represents a date range
-    dates_compressed: VecDeque<(i64, i64)>,
+/// Mutable per-ROA record used while building or updating the trie.
+#[derive(Debug, Clone)]
+pub struct RoaRecordMut {
+    pub max_len: u8,
+    pub origin: u32,
+    /// Uncompressed dates collected during bootstrap.
+    #[cfg_attr(feature = "legacy", allow(dead_code))]
+    pub(crate) dates: HashSet<i64>,
+    /// Compressed date ranges.
+    pub(crate) ranges: Vec<(i64, i64)>,
+}
+
+impl RoaRecordMut {
+    /// Create an empty record for legacy import.
+    #[cfg(feature = "legacy")]
+    pub(crate) fn new_legacy(max_len: u8, origin: u32) -> Self {
+        RoaRecordMut {
+            max_len,
+            origin,
+            dates: HashSet::new(),
+            ranges: Vec::new(),
+        }
+    }
+
+    fn new(date_ts: i64, max_len: u8, origin: u32, bootstrap: bool) -> Self {
+        if bootstrap {
+            RoaRecordMut {
+                max_len,
+                origin,
+                dates: HashSet::from([date_ts]),
+                ranges: Vec::new(),
+            }
+        } else {
+            RoaRecordMut {
+                max_len,
+                origin,
+                dates: HashSet::new(),
+                ranges: vec![(date_ts, date_ts)],
+            }
+        }
+    }
+
+    fn push_date(&mut self, date_ts: i64, bootstrap: bool) {
+        if bootstrap {
+            self.dates.insert(date_ts);
+            return;
+        }
+        match self.ranges.last_mut() {
+            None => self.ranges.push((date_ts, date_ts)),
+            Some((_, end)) => {
+                let next_day_ts = *end + ONE_DAY_SECONDS;
+                if date_ts == next_day_ts {
+                    *end = date_ts;
+                } else if date_ts > next_day_ts {
+                    self.ranges.push((date_ts, date_ts));
+                }
+                // date_ts <= end: already covered, skip
+            }
+        }
+    }
+
+    /// Merge `dates` into `ranges`, producing the final compressed ranges.
+    fn full_compress(&mut self) {
+        let mut all: Vec<i64> = self.dates.iter().copied().collect();
+        self.dates.clear();
+        for (start, end) in self.ranges.iter() {
+            let mut d = *start;
+            while d <= *end {
+                all.push(d);
+                d += ONE_DAY_SECONDS;
+            }
+        }
+        all.sort_unstable();
+
+        let mut compressed: Vec<(i64, i64)> = Vec::new();
+        if all.is_empty() {
+            self.ranges = compressed;
+            return;
+        }
+        let mut start = all[0];
+        let mut end = all[0];
+        for d in all.iter().skip(1) {
+            if *d == end + ONE_DAY_SECONDS {
+                end = *d;
+            } else {
+                compressed.push((start, end));
+                start = *d;
+                end = *d;
+            }
+        }
+        compressed.push((start, end));
+        self.ranges = compressed;
+    }
+}
+
+/// The serialized archive: header metadata plus the prefix trie.
+#[derive(Archive, Serialize, Deserialize)]
+pub struct RoasTrieData {
+    pub format_version: u32,
+    pub latest_date: i64,
+    pub ipv4_count: u64,
+    pub ipv6_count: u64,
+    pub trie: JointPrefixMap<IpNet, Vec<RoaRecord>>,
 }
 
 #[derive(Debug, Clone)]
@@ -90,102 +194,6 @@ impl From<RoasLookupEntry> for RoasLookupEntryTabled {
     }
 }
 
-impl RoasTrieEntry {
-    pub fn new(date_ts: i64, max_len: u8, origin: u32, bootstrap: bool) -> RoasTrieEntry {
-        match bootstrap {
-            true => RoasTrieEntry {
-                max_len,
-                origin,
-                dates: HashSet::from([date_ts]),
-                dates_compressed: VecDeque::new(),
-            },
-
-            false => RoasTrieEntry {
-                max_len,
-                origin,
-                dates: HashSet::new(),
-                dates_compressed: VecDeque::from([(date_ts, date_ts)]),
-            },
-        }
-    }
-
-    /// Do full compression where we explode the dates_compressed into individual dates and
-    /// then compress them again with the new dates
-    pub fn full_compress(&mut self) {
-        let mut dates = self.dates.iter().copied().collect::<Vec<i64>>();
-        self.dates.clear();
-
-        // explode the dates_compressed into individual dates
-        for (start, end) in self.dates_compressed.iter() {
-            let mut date = *start;
-            while date <= *end {
-                dates.push(date);
-                date += chrono::Duration::days(1).num_seconds();
-            }
-        }
-
-        // sort the dates
-        dates.sort();
-
-        // compress the dates
-        let mut compressed = VecDeque::new();
-        let mut start = dates[0];
-        let mut end = dates[0];
-        for d in dates.iter().skip(1) {
-            if *d == end + chrono::Duration::days(1).num_seconds() {
-                end = *d;
-            } else {
-                compressed.push_back((start, end));
-                start = *d;
-                end = *d;
-            }
-        }
-        compressed.push_back((start, end));
-
-        self.dates_compressed = compressed;
-
-        // after the full compression, the dates HashSet should be empty
-        assert!(self.dates.is_empty());
-    }
-
-    /// Push a new date: if bootstrap is true, push to hashSet, otherwise push to VecDeque
-    pub fn push_date(&mut self, date_ts: i64, bootstrap: bool) {
-        match bootstrap {
-            true => {
-                self.dates.insert(date_ts);
-            }
-            false => {
-                if self.dates_compressed.is_empty() {
-                    self.dates_compressed.push_back((date_ts, date_ts));
-                } else {
-                    let (_start, end) = self.dates_compressed.back_mut().unwrap();
-                    let next_day_ts = *end + chrono::Duration::days(1).num_seconds();
-
-                    match date_ts.cmp(&next_day_ts) {
-                        Ordering::Equal => {
-                            *end = date_ts;
-                        }
-                        Ordering::Greater => {
-                            self.dates_compressed.push_back((date_ts, date_ts));
-                        }
-                        Ordering::Less => {
-                            // the date is already in the range or in the past, skip
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    pub fn contains_date(&self, date_ts: i64) -> bool {
-        self.dates.contains(&date_ts)
-            || self
-                .dates_compressed
-                .iter()
-                .any(|(start, end)| date_ts >= *start && date_ts <= *end)
-    }
-}
-
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum RpkiValidation {
     Valid,
@@ -193,110 +201,130 @@ pub enum RpkiValidation {
     Unknown,
 }
 
-impl RoasTrieEntry {
-    fn convert_to_hash_map(self) -> HashMap<(u8, u32), RoasTrieEntry> {
-        HashMap::from([((self.max_len, self.origin), self)])
+impl std::fmt::Display for RpkiValidation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RpkiValidation::Valid => write!(f, "valid"),
+            RpkiValidation::Invalid => write!(f, "invalid"),
+            RpkiValidation::Unknown => write!(f, "unknown"),
+        }
     }
 }
 
-impl Default for RoasTrie {
+fn ts_to_date(ts: i64) -> NaiveDate {
+    chrono::DateTime::from_timestamp(ts, 0)
+        .unwrap()
+        .naive_utc()
+        .date()
+}
+
+fn date_to_ts(date: NaiveDate) -> i64 {
+    date.and_time(chrono::NaiveTime::from_hms_opt(0, 0, 0).unwrap())
+        .and_utc()
+        .timestamp()
+}
+
+/// Builder/mutable trie for rebuild, update, and fix operations.
+pub struct RoasTrieMut {
+    trie: JointPrefixMap<IpNet, Vec<RoaRecordMut>>,
+    latest_date: i64,
+}
+
+impl Default for RoasTrieMut {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl RoasTrie {
-    pub fn new() -> RoasTrie {
-        RoasTrie {
-            trie: IpnetTrie::new(),
+impl RoasTrieMut {
+    pub fn new() -> Self {
+        RoasTrieMut {
+            trie: JointPrefixMap::new(),
             latest_date: 0,
         }
     }
 
-    pub fn load(path: &str) -> Result<RoasTrie> {
+    /// Load a v2 archive from disk into a mutable trie for updating.
+    pub fn load(path: &str) -> Result<Self> {
         info!("loading trie from {} ...", path);
-        let mut reader = oneio::get_reader(path)?;
-        let mut trie: IpnetTrie<HashMap<(u8, u32), RoasTrieEntry>> = IpnetTrie::new();
-        trie.import_from_reader(&mut reader)?;
-        let mut roas_trie = RoasTrie {
+        let mut bytes = Vec::new();
+        oneio::get_reader(path)?.read_to_end(&mut bytes)?;
+        let data: RoasTrieData = rkyv::from_bytes::<_, rkyv::rancor::Error>(&bytes)
+            .map_err(|e| anyhow!("failed to deserialize trie archive: {}", e))?;
+        if data.format_version != FORMAT_VERSION {
+            return Err(anyhow!(
+                "unsupported trie format version {} (expected {})",
+                data.format_version,
+                FORMAT_VERSION
+            ));
+        }
+        let mut trie: JointPrefixMap<IpNet, Vec<RoaRecordMut>> = JointPrefixMap::new();
+        for (prefix, records) in data.trie.iter() {
+            let recs: Vec<RoaRecordMut> = records
+                .iter()
+                .map(|r| RoaRecordMut {
+                    max_len: r.max_len,
+                    origin: r.origin,
+                    dates: HashSet::new(),
+                    ranges: r.dates.clone(),
+                })
+                .collect();
+            trie.insert(prefix, recs);
+        }
+        info!(
+            "loaded {} prefixes, latest date {}",
+            trie.len(),
+            ts_to_date(data.latest_date)
+        );
+        Ok(RoasTrieMut {
             trie,
-            latest_date: 0,
+            latest_date: data.latest_date,
+        })
+    }
+
+    /// Compress all in-flight dates and serialize the trie to `path` (atomically).
+    pub fn dump(&mut self, path: &str) -> Result<()> {
+        info!("compressing dates into date ranges...");
+        self.compress_dates();
+
+        let mut v4_count: u64 = 0;
+        let mut v6_count: u64 = 0;
+        let mut out: JointPrefixMap<IpNet, Vec<RoaRecord>> = JointPrefixMap::new();
+        for (prefix, records) in self.trie.iter() {
+            match prefix {
+                IpNet::V4(_) => v4_count += 1,
+                IpNet::V6(_) => v6_count += 1,
+            }
+            let recs: Vec<RoaRecord> = records
+                .iter()
+                .map(|r| RoaRecord {
+                    max_len: r.max_len,
+                    origin: r.origin,
+                    dates: r.ranges.clone(),
+                })
+                .collect();
+            out.insert(prefix, recs);
+        }
+
+        let data = RoasTrieData {
+            format_version: FORMAT_VERSION,
+            latest_date: self.latest_date,
+            ipv4_count: v4_count,
+            ipv6_count: v6_count,
+            trie: out,
         };
-        roas_trie.update_latest_date();
-        Ok(roas_trie)
-    }
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&data)
+            .map_err(|e| anyhow!("failed to serialize trie: {}", e))?;
 
-    pub fn fill_gaps(&mut self) {
-        info!("filling known gaps...");
-        const ONE_DAY_SECONDS: i64 = 86400;
-
-        for (start, end) in KNOWN_GAPS_STR.iter() {
-            let start_ts = chrono::NaiveDate::parse_from_str(start, "%Y-%m-%d")
-                .unwrap()
-                .and_hms_opt(0, 0, 0)
-                .unwrap()
-                .and_utc()
-                .timestamp();
-            let end_ts = chrono::NaiveDate::parse_from_str(end, "%Y-%m-%d")
-                .unwrap()
-                .and_hms_opt(0, 0, 0)
-                .unwrap()
-                .and_utc()
-                .timestamp();
-
-            // vector of timestamps from start_ts to end_ts
-            let mut dates = Vec::new();
-            let mut date = start_ts;
-            while date <= end_ts {
-                dates.push(date);
-                date += ONE_DAY_SECONDS;
-            }
-
-            for (_prefix, map) in self.trie.iter_mut() {
-                for entry in map.values_mut() {
-                    let mut should_compress = false;
-                    for i in 0..entry.dates_compressed.len() - 1 {
-                        // let (start, end) = entry.dates_compressed[i];
-                        if start_ts - ONE_DAY_SECONDS == entry.dates_compressed[i].1
-                            && end_ts + ONE_DAY_SECONDS == entry.dates_compressed[i + 1].0
-                        {
-                            entry.dates.extend(&dates);
-                            should_compress = true;
-                        }
-                    }
-                    if should_compress {
-                        entry.full_compress();
-                    }
-                }
-            }
-        }
-        info!("filling known gaps... done");
-    }
-
-    fn update_latest_date(&mut self) {
-        let mut latest_date = 0;
-        for (_prefix, map) in self.trie.iter() {
-            for entry in map.values() {
-                if let Some(date) = entry.dates.iter().max() {
-                    if *date > latest_date {
-                        latest_date = *date;
-                    }
-                }
-                if let Some((_, end)) = entry.dates_compressed.back() {
-                    if *end > latest_date {
-                        latest_date = *end;
-                    }
-                }
-            }
-        }
-        self.latest_date = latest_date;
-        info!("updating latest date to {}", self.get_latest_date());
-    }
-
-    pub fn dump(&self, path: &str) -> Result<()> {
-        info!("exporting trie to {} ...", path);
-        let mut writer = oneio::get_writer(path)?;
-        self.trie.export_to_writer(&mut writer)?;
+        info!(
+            "exporting trie to {} ({} prefixes, {:.1} MB) ...",
+            path,
+            data.trie.len(),
+            bytes.len() as f64 / 1024.0 / 1024.0
+        );
+        let tmp_path = format!("{}.tmp", path);
+        std::fs::write(&tmp_path, &bytes)?;
+        std::fs::rename(&tmp_path, path)?;
         Ok(())
     }
 
@@ -311,26 +339,23 @@ impl RoasTrie {
             let prefix = entry.prefix;
             let max_len = entry.max_len as u8;
             let origin = entry.asn;
-            let date_ts = entry
-                .date
-                .and_time(chrono::NaiveTime::from_hms_opt(0, 0, 0).unwrap())
-                .and_utc()
-                .timestamp();
+            let date_ts = date_to_ts(entry.date);
 
-            match self.trie.exact_match_mut(prefix) {
-                Some(v) => {
-                    v.entry((max_len, origin))
-                        .and_modify(|e| e.push_date(date_ts, bootstrap))
-                        .or_insert_with(|| RoasTrieEntry::new(date_ts, max_len, origin, bootstrap));
-                }
+            match self.trie.get_mut(&prefix) {
+                Some(recs) => match recs
+                    .iter_mut()
+                    .find(|r| r.max_len == max_len && r.origin == origin)
+                {
+                    Some(r) => r.push_date(date_ts, bootstrap),
+                    None => recs.push(RoaRecordMut::new(date_ts, max_len, origin, bootstrap)),
+                },
                 None => {
                     self.trie.insert(
                         prefix,
-                        RoasTrieEntry::new(date_ts, max_len, origin, bootstrap)
-                            .convert_to_hash_map(),
+                        vec![RoaRecordMut::new(date_ts, max_len, origin, bootstrap)],
                     );
                 }
-            };
+            }
 
             if date_ts > self.latest_date {
                 self.latest_date = date_ts;
@@ -339,169 +364,18 @@ impl RoasTrie {
     }
 
     pub fn get_latest_date(&self) -> NaiveDate {
-        chrono::DateTime::from_timestamp(self.latest_date, 0)
-            .unwrap()
-            .naive_utc()
-            .date()
+        ts_to_date(self.latest_date)
     }
 
-    pub fn compress_dates(&mut self) {
-        info!("compressing dates into date ranges...");
-        for (_prefix, map) in self.trie.iter_mut() {
-            for entry in map.values_mut() {
-                entry.full_compress();
+    fn compress_dates(&mut self) {
+        for (_prefix, records) in self.trie.iter_mut() {
+            for r in records.iter_mut() {
+                r.full_compress();
             }
         }
     }
 
-    pub fn validate(&self, prefix: &IpNet, origin: u32, date_ts: i64) -> RpkiValidation {
-        let mut is_valid = RpkiValidation::Unknown;
-        'outer: for matched in self.trie.matches(prefix) {
-            for entry in matched.1.values() {
-                if entry.origin == origin
-                    && entry.max_len >= prefix.prefix_len()
-                    && entry.contains_date(date_ts)
-                {
-                    is_valid = RpkiValidation::Valid;
-                    break 'outer;
-                }
-            }
-            is_valid = RpkiValidation::Invalid;
-        }
-
-        is_valid
-    }
-
-    pub fn lookup_prefix(&self, prefix: &IpNet) -> Vec<RoasLookupEntry> {
-        let mut entries = Vec::new();
-        for (prefix, map) in self.trie.matches(prefix) {
-            for entry in map.values() {
-                entries.push(RoasLookupEntry {
-                    prefix,
-                    origin: entry.origin,
-                    max_len: entry.max_len,
-                    dates_ranges: entry
-                        .dates_compressed
-                        .iter()
-                        .map(|(start, end)| {
-                            (
-                                chrono::DateTime::from_timestamp(*start, 0)
-                                    .unwrap()
-                                    .naive_utc()
-                                    .date(),
-                                chrono::DateTime::from_timestamp(*end, 0)
-                                    .unwrap()
-                                    .naive_utc()
-                                    .date(),
-                            )
-                        })
-                        .collect(),
-                });
-            }
-        }
-        entries
-    }
-
-    pub fn search(
-        &self,
-        prefix: Option<IpNet>,
-        origin: Option<u32>,
-        max_len: Option<u8>,
-        date: Option<NaiveDate>,
-        current: Option<bool>,
-        exact: bool,
-    ) -> Vec<RoasLookupEntry> {
-        let mut entries = Vec::new();
-
-        // prefix filter: exact match by default (fixes issue #9),
-        // falls back to matches() when exact=false for supernet/subnet inclusion
-        let iter: Vec<(IpNet, &RoasTrieMap)> = match prefix {
-            Some(prefix) if exact => match self.trie.exact_match(prefix) {
-                Some(map) => vec![(prefix, map)],
-                None => vec![],
-            },
-            Some(prefix) => self.trie.matches(&prefix),
-            None => self.trie.iter().collect(),
-        };
-
-        let mut only_expired = false;
-
-        let date = match current {
-            Some(c) => match c {
-                true => Some(self.latest_date),
-                false => {
-                    only_expired = true;
-                    None
-                }
-            },
-            None => date.map(|d| {
-                d.and_time(chrono::NaiveTime::from_hms_opt(0, 0, 0).unwrap())
-                    .and_utc()
-                    .timestamp()
-            }),
-        };
-
-        for (prefix, map) in iter {
-            for entry in map.values() {
-                if let Some(origin) = origin {
-                    if entry.origin != origin {
-                        continue;
-                    }
-                }
-
-                if let Some(max_len) = max_len {
-                    if entry.max_len != max_len {
-                        continue;
-                    }
-                }
-
-                if let Some(date) = date {
-                    // check if date_ts is within one of the date ranges in entry.dates_compressed
-                    if entry
-                        .dates_compressed
-                        .iter()
-                        .all(|(start, end)| date < *start || date > *end)
-                    {
-                        continue;
-                    }
-                }
-
-                if only_expired
-                    && entry
-                        .dates_compressed
-                        .iter()
-                        .any(|(_, end)| *end >= self.latest_date)
-                {
-                    // if any of the date ranges is still current, the entry is current, skip
-                    continue;
-                }
-
-                entries.push(RoasLookupEntry {
-                    prefix,
-                    origin: entry.origin,
-                    max_len: entry.max_len,
-                    dates_ranges: entry
-                        .dates_compressed
-                        .iter()
-                        .map(|(start, end)| {
-                            (
-                                chrono::DateTime::from_timestamp(*start, 0)
-                                    .unwrap()
-                                    .naive_utc()
-                                    .date(),
-                                chrono::DateTime::from_timestamp(*end, 0)
-                                    .unwrap()
-                                    .naive_utc()
-                                    .date(),
-                            )
-                        })
-                        .collect(),
-                });
-            }
-        }
-        entries
-    }
-
+    /// Incremental update: crawl new ROA files since `latest_date` and apply.
     pub fn update(&mut self, tal: Option<String>, until: Option<NaiveDate>) -> Result<()> {
         info!("updating trie... tal: {:?}, until: {:?}", &tal, &until);
         let mut all_files = get_tal_urls(tal)
@@ -520,68 +394,369 @@ impl RoasTrie {
             return Ok(());
         }
 
-        // sort by date
         all_files.sort_by_key(|a| a.file_date);
 
-        for file in all_files {
+        let mut failed = 0usize;
+        for file in &all_files {
             info!("processing {}", file.url.as_str());
-            let url: &str = file.url.as_str();
-            if let Ok(roas) = parse_roas_csv(url) {
-                self.process_entries(&roas, false);
+            match parse_roas_csv(file.url.as_str()) {
+                Ok(roas) => self.process_entries(&roas, false),
+                Err(e) => {
+                    failed += 1;
+                    warn!("failed to process {}: {}", file.url, e);
+                }
             }
+        }
+        if failed > 0 {
+            warn!(
+                "update finished with {} failed file(s) out of {}",
+                failed,
+                all_files.len()
+            );
         }
 
         info!("updating trie... done");
         Ok(())
     }
 
-    pub fn replace(&mut self, other: RoasTrie) {
-        self.trie = other.trie;
-        self.latest_date = other.latest_date;
+    /// Fill known historical data gaps by interpolating adjacent date ranges.
+    pub fn fill_gaps(&mut self) {
+        info!("filling known gaps...");
+        for (start, end) in KNOWN_GAPS_STR.iter() {
+            let start_ts = date_to_ts(NaiveDate::parse_from_str(start, "%Y-%m-%d").unwrap());
+            let end_ts = date_to_ts(NaiveDate::parse_from_str(end, "%Y-%m-%d").unwrap());
+
+            let mut dates = Vec::new();
+            let mut d = start_ts;
+            while d <= end_ts {
+                dates.push(d);
+                d += ONE_DAY_SECONDS;
+            }
+
+            for (_prefix, records) in self.trie.iter_mut() {
+                for r in records.iter_mut() {
+                    let mut should_compress = false;
+                    for i in 0..r.ranges.len().saturating_sub(1) {
+                        if start_ts - ONE_DAY_SECONDS == r.ranges[i].1
+                            && end_ts + ONE_DAY_SECONDS == r.ranges[i + 1].0
+                        {
+                            r.dates.extend(&dates);
+                            should_compress = true;
+                        }
+                    }
+                    if should_compress {
+                        r.full_compress();
+                    }
+                }
+            }
+        }
+        info!("filling known gaps... done");
+    }
+
+    pub fn len(&self) -> usize {
+        self.trie.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.trie.is_empty()
+    }
+
+    /// Insert a single record under `prefix` (legacy import path).
+    #[cfg(feature = "legacy")]
+    pub(crate) fn insert_record(&mut self, prefix: IpNet, record: RoaRecordMut) {
+        match self.trie.get_mut(&prefix) {
+            Some(recs) => recs.push(record),
+            None => {
+                self.trie.insert(prefix, vec![record]);
+            }
+        }
+    }
+
+    /// Set the latest date (legacy import path).
+    #[cfg(feature = "legacy")]
+    pub(crate) fn set_latest_date(&mut self, ts: i64) {
+        self.latest_date = ts;
     }
 }
+
+/// Read-only trie backed by an rkyv archive, either memory-mapped from disk
+/// or held as owned bytes. Queries run directly on the archived bytes without
+/// deserializing the trie into heap structures.
+pub struct RoasTrie {
+    bytes: TrieBytes,
+}
+
+enum TrieBytes {
+    Mmap(memmap2::Mmap),
+    Owned(Vec<u8>),
+}
+
+impl TrieBytes {
+    fn as_slice(&self) -> &[u8] {
+        match self {
+            TrieBytes::Mmap(m) => m.as_ref(),
+            TrieBytes::Owned(v) => v.as_slice(),
+        }
+    }
+}
+
+impl RoasTrie {
+    /// Open a v2 archive file read-only via memory map. The file is validated
+    /// once on open; queries then run directly against the mapped bytes.
+    pub fn open(path: &str) -> Result<Self> {
+        let file = std::fs::File::open(path)?;
+        // SAFETY: the file is opened read-only and the mapping is never mutated.
+        let mmap = unsafe { memmap2::Mmap::map(&file)? };
+        let trie = RoasTrie {
+            bytes: TrieBytes::Mmap(mmap),
+        };
+        trie.validate_bytes()?;
+        Ok(trie)
+    }
+
+    /// Create a read handle from owned archive bytes (e.g. freshly serialized).
+    pub fn from_bytes(bytes: Vec<u8>) -> Result<Self> {
+        let trie = RoasTrie {
+            bytes: TrieBytes::Owned(bytes),
+        };
+        trie.validate_bytes()?;
+        Ok(trie)
+    }
+
+    fn validate_bytes(&self) -> Result<()> {
+        let data: &ArchivedRoasTrieData =
+            rkyv::access::<_, rkyv::rancor::Error>(self.bytes.as_slice())
+                .map_err(|e| anyhow!("trie archive validation failed: {}", e))?;
+        if data.format_version.to_native() != FORMAT_VERSION {
+            return Err(anyhow!(
+                "unsupported trie format version {} (expected {})",
+                data.format_version.to_native(),
+                FORMAT_VERSION
+            ));
+        }
+        Ok(())
+    }
+
+    /// Access the archived data.
+    fn data(&self) -> &ArchivedRoasTrieData {
+        // SAFETY: the bytes were validated in full at open()/from_bytes() and
+        // are immutable for the lifetime of this struct.
+        unsafe { rkyv::access_unchecked::<ArchivedRoasTrieData>(self.bytes.as_slice()) }
+    }
+
+    pub fn latest_date_ts(&self) -> i64 {
+        self.data().latest_date.to_native()
+    }
+
+    pub fn get_latest_date(&self) -> NaiveDate {
+        ts_to_date(self.latest_date_ts())
+    }
+
+    pub fn counts(&self) -> (u64, u64) {
+        let data = self.data();
+        (data.ipv4_count.to_native(), data.ipv6_count.to_native())
+    }
+
+    /// Total number of prefix entries.
+    pub fn len(&self) -> usize {
+        self.data().trie.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// RPKI validation for a prefix/origin at a given date.
+    pub fn validate(&self, prefix: &IpNet, origin: u32, date_ts: i64) -> RpkiValidation {
+        let mut result = RpkiValidation::Unknown;
+        let prefix_len = prefix.prefix_len();
+        for (_p, records) in self.match_records(prefix) {
+            for r in records.iter() {
+                let r_origin = r.origin.to_native();
+                let r_max_len = r.max_len;
+                if r_origin == origin && r_max_len >= prefix_len && record_contains_date(r, date_ts)
+                {
+                    return RpkiValidation::Valid;
+                }
+            }
+            result = RpkiValidation::Invalid;
+        }
+        result
+    }
+
+    /// All ROA records matching a prefix, including supernets and subnets.
+    pub fn lookup_prefix(&self, prefix: &IpNet) -> Vec<RoasLookupEntry> {
+        let mut entries = Vec::new();
+        for (p, records) in self.match_records(prefix) {
+            for r in records.iter() {
+                entries.push(archived_lookup_entry(p, r));
+            }
+        }
+        entries
+    }
+
+    /// Search ROAs with optional filters. `exact=true` restricts to the exact
+    /// prefix; `exact=false` includes supernets and subnets (matching the old
+    /// `matches()` semantics: the subtree of the shortest covering prefix).
+    pub fn search(
+        &self,
+        prefix: Option<IpNet>,
+        origin: Option<u32>,
+        max_len: Option<u8>,
+        date: Option<NaiveDate>,
+        current: Option<bool>,
+        exact: bool,
+    ) -> Vec<RoasLookupEntry> {
+        let mut only_expired = false;
+        let date_ts = match current {
+            Some(true) => Some(self.latest_date_ts()),
+            Some(false) => {
+                only_expired = true;
+                None
+            }
+            None => date.map(date_to_ts),
+        };
+        let latest = self.latest_date_ts();
+
+        let mut entries = Vec::new();
+        for (p, records) in self.select_records(prefix, exact) {
+            // deterministic order within a prefix (v1 was nondeterministic HashMap order)
+            let mut sorted: Vec<&ArchivedRoaRecord> = records.iter().collect();
+            sorted.sort_by_key(|r| (r.origin.to_native(), r.max_len));
+            for r in sorted {
+                if let Some(origin) = origin {
+                    if r.origin.to_native() != origin {
+                        continue;
+                    }
+                }
+                if let Some(max_len) = max_len {
+                    if r.max_len != max_len {
+                        continue;
+                    }
+                }
+                if let Some(date_ts) = date_ts {
+                    if !record_contains_date(r, date_ts) {
+                        continue;
+                    }
+                }
+                if only_expired && r.dates.iter().any(|range| range.1.to_native() >= latest) {
+                    continue;
+                }
+                entries.push(archived_lookup_entry(p, r));
+            }
+        }
+        entries
+    }
+
+    /// Select (prefix, records) pairs according to the prefix filter mode.
+    fn select_records(
+        &self,
+        prefix: Option<IpNet>,
+        exact: bool,
+    ) -> Vec<(IpNet, &ArchivedVec<ArchivedRoaRecord>)> {
+        match prefix {
+            Some(p) if exact => match self.data().trie.get(&p) {
+                Some(recs) => vec![(p, recs)],
+                None => vec![],
+            },
+            Some(p) => self.match_records(&p),
+            None => self.data().trie.iter().collect(),
+        }
+    }
+
+    /// Entries matching `prefix` with old `IpnetTrie::matches()` semantics:
+    /// the shortest covering prefix and its entire subtree.
+    fn match_records<'a>(
+        &'a self,
+        prefix: &IpNet,
+    ) -> Vec<(IpNet, &'a ArchivedVec<ArchivedRoaRecord>)> {
+        let data = self.data();
+        let spm = match data.trie.get_spm(prefix) {
+            Some((spm, _)) => spm,
+            None => return vec![],
+        };
+        match spm {
+            IpNet::V4(spm4) => match (&data.trie.t1).view_at(&spm4) {
+                Some(view) => view.iter().map(|(p, recs)| (IpNet::V4(p), recs)).collect(),
+                None => vec![],
+            },
+            IpNet::V6(spm6) => match (&data.trie.t2).view_at(&spm6) {
+                Some(view) => view.iter().map(|(p, recs)| (IpNet::V6(p), recs)).collect(),
+                None => vec![],
+            },
+        }
+    }
+}
+
+fn record_contains_date(r: &ArchivedRoaRecord, date_ts: i64) -> bool {
+    r.dates.iter().any(|range| {
+        let start = range.0.to_native();
+        let end = range.1.to_native();
+        date_ts >= start && date_ts <= end
+    })
+}
+
+fn archived_lookup_entry(prefix: IpNet, r: &ArchivedRoaRecord) -> RoasLookupEntry {
+    RoasLookupEntry {
+        prefix,
+        origin: r.origin.to_native(),
+        max_len: r.max_len,
+        dates_ranges: r
+            .dates
+            .iter()
+            .map(|range| {
+                (
+                    ts_to_date(range.0.to_native()),
+                    ts_to_date(range.1.to_native()),
+                )
+            })
+            .collect(),
+    }
+}
+
+// Re-export for convenience of the API layer.
+pub use rkyv::vec::ArchivedVec;
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::RoaEntry;
-    use chrono::NaiveDate;
-    use ipnet::IpNet;
-    use std::net::Ipv4Addr;
-    use std::str::FromStr;
 
     fn make_entry(prefix: &str, asn: u32, max_len: i32, date: NaiveDate) -> RoaEntry {
         RoaEntry {
             tal: "test".to_string(),
-            prefix: IpNet::from_str(prefix).unwrap(),
+            prefix: prefix.parse().unwrap(),
             max_len,
             asn,
             date,
         }
     }
 
-    fn build_test_trie() -> RoasTrie {
+    fn build_test_trie(name: &str) -> RoasTrie {
         let date = NaiveDate::from_ymd_opt(2024, 1, 1).unwrap();
         let entries = vec![
-            // supernet
             make_entry("1.0.0.0/8", 64512, 8, date),
-            // exact prefix we will search for
             make_entry("1.1.1.0/24", 13335, 24, date),
-            // subnet (more-specific)
             make_entry("1.1.1.0/25", 64513, 25, date),
         ];
-        let mut trie = RoasTrie::new();
+        let mut trie = RoasTrieMut::new();
         trie.process_entries(&entries, true);
-        trie.compress_dates();
-        trie
+        // serialize in-memory and re-open
+        let tmp = std::env::temp_dir().join(format!(
+            "wayback-rpki-test-{}-{}.rkyv",
+            name,
+            std::process::id()
+        ));
+        trie.dump(tmp.to_str().unwrap()).unwrap();
+        let t = RoasTrie::open(tmp.to_str().unwrap()).unwrap();
+        let _ = std::fs::remove_file(&tmp);
+        t
     }
 
     #[test]
     fn test_search_exact_returns_only_matching_prefix() {
-        let trie = build_test_trie();
-        let prefix = IpNet::V4(ipnet::Ipv4Net::new(Ipv4Addr::new(1, 1, 1, 0), 24).unwrap());
+        let trie = build_test_trie(concat!("t", line!()));
+        let prefix: IpNet = "1.1.1.0/24".parse().unwrap();
 
-        // exact=true should return only the /24 ROA
         let results = trie.search(Some(prefix), None, None, None, None, true);
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].prefix.to_string(), "1.1.1.0/24");
@@ -590,10 +765,9 @@ mod tests {
 
     #[test]
     fn test_search_non_exact_includes_super_and_sub() {
-        let trie = build_test_trie();
-        let prefix = IpNet::V4(ipnet::Ipv4Net::new(Ipv4Addr::new(1, 1, 1, 0), 24).unwrap());
+        let trie = build_test_trie(concat!("t", line!()));
+        let prefix: IpNet = "1.1.1.0/24".parse().unwrap();
 
-        // exact=false should use matches(), which includes the supernet and subnet
         let results = trie.search(Some(prefix), None, None, None, None, false);
         let prefixes: Vec<String> = results.iter().map(|r| r.prefix.to_string()).collect();
         assert!(prefixes.contains(&"1.0.0.0/8".to_string()));
@@ -603,9 +777,8 @@ mod tests {
 
     #[test]
     fn test_search_exact_no_match_returns_empty() {
-        let trie = build_test_trie();
-        // prefix not in trie
-        let prefix = IpNet::V4(ipnet::Ipv4Net::new(Ipv4Addr::new(2, 2, 2, 0), 24).unwrap());
+        let trie = build_test_trie(concat!("t", line!()));
+        let prefix: IpNet = "2.2.2.0/24".parse().unwrap();
 
         let results = trie.search(Some(prefix), None, None, None, None, true);
         assert!(results.is_empty());
@@ -613,10 +786,31 @@ mod tests {
 
     #[test]
     fn test_search_no_prefix_returns_all() {
-        let trie = build_test_trie();
+        let trie = build_test_trie(concat!("t", line!()));
 
-        // No prefix filter → return all entries regardless of exact flag
         let results = trie.search(None, None, None, None, None, true);
+        assert_eq!(results.len(), 3);
+    }
+
+    #[test]
+    fn test_validate() {
+        let trie = build_test_trie(concat!("t", line!()));
+        let date = NaiveDate::from_ymd_opt(2024, 1, 1).unwrap();
+        let ts = date_to_ts(date);
+
+        let prefix: IpNet = "1.1.1.0/24".parse().unwrap();
+        assert_eq!(trie.validate(&prefix, 13335, ts), RpkiValidation::Valid);
+        assert_eq!(trie.validate(&prefix, 64512, ts), RpkiValidation::Invalid);
+
+        let unknown: IpNet = "9.9.9.0/24".parse().unwrap();
+        assert_eq!(trie.validate(&unknown, 13335, ts), RpkiValidation::Unknown);
+    }
+
+    #[test]
+    fn test_lookup_prefix() {
+        let trie = build_test_trie(concat!("t", line!()));
+        let prefix: IpNet = "1.1.1.0/24".parse().unwrap();
+        let results = trie.lookup_prefix(&prefix);
         assert_eq!(results.len(), 3);
     }
 }

--- a/src/roas_trie.rs
+++ b/src/roas_trie.rs
@@ -16,7 +16,7 @@ pub const FORMAT_VERSION: u32 = 2;
 /// Default remote bootstrap archive URL (v2 rkyv format).
 pub const REMOTE_BOOTSTRAP_URL: &str = "https://spaces.bgpkit.org/broker/roas_trie.rkyv";
 
-const KNOWN_GAPS_STR: [(&str, &str); 24] = [
+pub(crate) const KNOWN_GAPS_STR: [(&str, &str); 24] = [
     ("2018-12-28", "2019-01-02"),
     ("2019-10-22", "2019-10-22"),
     ("2019-11-24", "2019-11-24"),
@@ -63,7 +63,7 @@ pub struct RoaRecordMut {
     pub max_len: u8,
     pub origin: u32,
     /// Uncompressed dates collected during bootstrap.
-    #[cfg_attr(feature = "legacy", allow(dead_code))]
+    #[allow(dead_code)]
     pub(crate) dates: HashSet<i64>,
     /// Compressed date ranges.
     pub(crate) ranges: Vec<(i64, i64)>,
@@ -71,7 +71,7 @@ pub struct RoaRecordMut {
 
 impl RoaRecordMut {
     /// Create an empty record for legacy import.
-    #[cfg(feature = "legacy")]
+    #[allow(dead_code)]
     pub(crate) fn new_legacy(max_len: u8, origin: u32) -> Self {
         RoaRecordMut {
             max_len,
@@ -211,14 +211,14 @@ impl std::fmt::Display for RpkiValidation {
     }
 }
 
-fn ts_to_date(ts: i64) -> NaiveDate {
+pub(crate) fn ts_to_date(ts: i64) -> NaiveDate {
     chrono::DateTime::from_timestamp(ts, 0)
         .unwrap()
         .naive_utc()
         .date()
 }
 
-fn date_to_ts(date: NaiveDate) -> i64 {
+pub(crate) fn date_to_ts(date: NaiveDate) -> i64 {
     date.and_time(chrono::NaiveTime::from_hms_opt(0, 0, 0).unwrap())
         .and_utc()
         .timestamp()
@@ -461,8 +461,7 @@ impl RoasTrieMut {
         self.trie.is_empty()
     }
 
-    /// Insert a single record under `prefix` (legacy import path).
-    #[cfg(feature = "legacy")]
+    /// Insert a single record under `prefix`.
     pub(crate) fn insert_record(&mut self, prefix: IpNet, record: RoaRecordMut) {
         match self.trie.get_mut(&prefix) {
             Some(recs) => recs.push(record),
@@ -472,8 +471,7 @@ impl RoasTrieMut {
         }
     }
 
-    /// Set the latest date (legacy import path).
-    #[cfg(feature = "legacy")]
+    /// Set the latest date.
     pub(crate) fn set_latest_date(&mut self, ts: i64) {
         self.latest_date = ts;
     }


### PR DESCRIPTION
## Summary

Migrate `wayback-rpki` from `ipnet-trie` + `bincode` (v1) to `prefix-trie` + `rkyv` (v2) with zero-copy mmap serving, while preserving full backward compatibility with legacy `.bin`/`.bin.gz` archives during a transitional period.

## Changes

### Core migration
- Replace `ipnet-trie` with `prefix-trie` `JointPrefixMap`, serialized as a zero-copy rkyv archive
- Serve from mmap: RSS drops from ~756 MB to ~5 MB; startup from ~2.3 s to ~23 ms
- Archive updates use temp + atomic rename for safe hot-reload

### Legacy compatibility (always-on)
- `bincode` and `ipnet-trie` are required dependencies (no feature gate)
- `LegacyRoasTrie` wraps the full v1 query API (search, update, build, dump)
- Sibling `.bin[.gz]` files are auto-converted without prompting
- Explicit conversion: `wayback-rpki convert --from legacy.bin.gz trie.rkyv`

### Dual-mode routing
- `.rkyv` suffix → v2 mmap backend
- `.bin`/`.bin.gz` suffix → v1 legacy in-memory backend
- `TrieBackend` enum in the API handles both; `/health` reports `format_version`

### Bootstrap precedence
1. Existing local `.rkyv`
2. Local sibling `.bin.gz`/`.bin` → auto-convert
3. Remote `roas_trie.rkyv.gz` (gzip transport, decompressed to raw mmap)
4. Remote `roas_trie.bin.gz` → download → auto-convert (fallback for transitional period)

### Transport compression
- Active archives are raw (mmap requires uncompressed bytes)
- `.rkyv.gz` is transport-only: bootstrap downloads decompress via `oneio::copy`
- Backup destinations ending in `.rkyv.gz` are gzip-compressed before upload

### Docker fix
- `rust:1.90` now ships on Debian 13 (GLIBC 2.41); updated runtime to `debian:trixie-slim` to match

## Verification
- 16 unit tests pass (14 lib + 2 binary)
- `cargo clippy --all-features -- -D warnings` clean
- Release build passes
- End-to-end Docker bootstrap: remote `.rkyv.gz` (404) → fallback to `.bin.gz` → auto-convert → mmap serving
- Lookup queries return identical data to v1 (1.1M ROAs, AS13335, AS15169)
