### PR TITLE
2.0: JSONL.gz platform-agnostic transport (replaces rkyv.gz)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ Start the API with a one-command bootstrap (downloads pre-built trie from
 wayback-rpki serve --bootstrap
 ```
 
-This downloads the gzip-compressed bootstrap transport artifact, streams it into
-an uncompressed local `roas_trie.rkyv` archive, then memory-maps that raw file
-for the API on `0.0.0.0:40065`. The server updates every 8 hours.
+This downloads the platform-agnostic JSONL.gz transport archive, streams it
+through a builder to produce a local `roas_trie.rkyv`, then memory-maps that
+file for the API on `0.0.0.0:40065`. The server updates every 8 hours.
 
 ## CLI Usage
 
@@ -273,16 +273,22 @@ builder.dump("roas_trie.rkyv")?;
 | `RoasTrie::validate(...)` | RPKI validation → `Valid` / `Invalid` / `Unknown` |
 
 The on-disk v2 format is a raw `rkyv` archive (`RoasTrieData` with header
-metadata and a `JointPrefixMap`). Raw `.rkyv` files are mmap-ready; `.rkyv.gz`
-files are transport/backup artifacts only and are decompressed before serving.
+metadata and a `JointPrefixMap`). Raw `.rkyv` files are mmap-ready and
+platform-specific — they are **never used for transport or backup**.
+
+**Transport/backup format:** JSONL.gz — one line per `(prefix, max_len, origin)`
+ROA record with compressed date ranges. Platform-agnostic, streamable, and
+human-debuggable (`zcat roas_trie.jsonl.gz | head | jq .`).
 
 During the v2 transition, `.bin`/`.bin.gz` paths retain the legacy in-memory
-backend. A missing `roas_trie.rkyv` is automatically generated from a sibling
-`roas_trie.bin.gz` or `roas_trie.bin` **before any bootstrap download is
-attempted**, without prompting. If neither exists and the remote `.rkyv.gz`
-bootstrap is unavailable, bootstrap downloads the remote `.bin.gz` and converts
-it locally. Explicit conversion is also available as
-`wayback-rpki roas_trie.bin.gz convert --from roas_trie.bin.gz roas_trie.rkyv`.
+backend. A missing `roas_trie.rkyv` is auto-generated, in order:
+
+1. Local sibling `.bin.gz`/`.bin` → convert
+2. Remote `roas_trie.jsonl.gz` → stream-import → dump rkyv (preferred, ~200 MB peak RAM)
+3. Remote `roas_trie.bin.gz` → download → convert (legacy fallback)
+
+Explicit conversion is also available as
+`wayback-rpki convert --from roas_trie.bin.gz roas_trie.rkyv`.
 
 | `compress_dates()` | Merge consecutive dates into ranges |
 | `fill_gaps()` | Fill known historical data gaps |
@@ -293,7 +299,7 @@ The `serve` subcommand supports the following environment variables:
 
 | Variable | Description |
 |----------|-------------|
-| `WAYBACK_BACKUP_TO` | Backup destination (`r2://bucket/key` for S3/R2, or local path). A destination ending in `.rkyv.gz` is gzip-compressed for transport; the local serving archive remains raw/mmap-ready. |
+| `WAYBACK_BACKUP_TO` | Backup destination (`r2://bucket/key` for S3/R2, or local path). Backups are written as platform-agnostic JSONL.gz transport files streamed from the live mmap archive. |
 | `WAYBACK_BACKUP_HEARTBEAT_URL` | URL to ping after successful backup (e.g., UptimeRobot) |
 | `AWS_REGION` | S3/R2 region (required for R2 backups) |
 | `AWS_ENDPOINT` | S3/R2 endpoint (required for R2 backups) |

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -3,7 +3,6 @@ use clap::{Parser, Subcommand};
 use indicatif::{ProgressBar, ProgressStyle};
 use ipnet::IpNet;
 use rayon::prelude::*;
-use std::io::{copy, Write};
 use std::path::Path;
 use std::process::exit;
 use std::sync::Arc;
@@ -472,68 +471,57 @@ fn get_tokio_runtime() -> tokio::runtime::Runtime {
         .unwrap()
 }
 
-/// Stream a suffix-compressed source through oneio into an uncompressed local
-/// archive. The result is suitable for direct `mmap` access.
-fn download_rkyv_transport(url: &str, local_path: &str) -> anyhow::Result<()> {
-    let mut reader = oneio::get_reader(url)?;
-    let mut writer = std::fs::File::create(local_path)?;
-    copy(&mut reader, &mut writer)?;
-    writer.sync_all()?;
+/// Bootstrap a `.rkyv` archive from a remote JSONL.gz transport file.
+/// Downloads the compressed JSONL, streams it through a builder, and dumps
+/// the raw `.rkyv`. Peak memory is just the builder (~200 MB).
+fn bootstrap_from_jsonl(url: &str, rkyv_path: &str) -> anyhow::Result<()> {
+    let jsonl_path = format!(
+        "{}.jsonl.gz",
+        rkyv_path.strip_suffix(".rkyv").unwrap_or(rkyv_path)
+    );
+    info!("downloading JSONL transport {} to {}", url, jsonl_path);
+    oneio::download(url, &jsonl_path)?;
+
+    info!("building rkyv archive from JSONL...");
+    let mut builder = RoasTrieMut::from_jsonl(&jsonl_path)?;
+    builder.dump(rkyv_path)?;
+    info!("bootstrap complete: {}", rkyv_path);
     Ok(())
 }
 
-/// Create a gzip transport copy of a raw rkyv archive. The active archive is
-/// intentionally never gzip-compressed because rkyv serving requires mmap.
-fn create_rkyv_transport_gzip(source: &str) -> anyhow::Result<std::path::PathBuf> {
-    let temp = std::env::temp_dir().join(format!(
-        "wayback-rpki-{}-{}.rkyv.gz",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)?
-            .as_nanos()
-    ));
-    let mut reader = std::fs::File::open(source)?;
-    let mut writer = oneio::get_writer(temp.to_str().unwrap())?;
-    copy(&mut reader, &mut writer)?;
-    writer.flush()?;
-    drop(writer);
-    Ok(temp)
-}
-
-/// Write an archive backup. A `.rkyv.gz` destination is explicitly a
-/// transport artifact; the running service continues to mmap the raw `.rkyv`.
+/// Write a backup from the live `.rkyv` archive to a `.jsonl[.gz]` transport file.
+/// Streams zero-copy from the mmap'd archive — peak memory ~10 MB.
 fn backup_archive(source: &str, destination: &str) -> anyhow::Result<()> {
-    let temporary = if destination.ends_with(".rkyv.gz") {
-        Some(create_rkyv_transport_gzip(source)?)
-    } else {
-        None
-    };
-    let upload_source = temporary
-        .as_ref()
-        .and_then(|p| p.to_str())
-        .unwrap_or(source);
-
-    let result = match oneio::s3_url_parse(destination) {
+    let trie = RoasTrie::open(source)?;
+    match oneio::s3_url_parse(destination) {
         Ok((bucket, key)) => {
+            // For S3, write to a local temp file first, then upload.
+            let temp = std::env::temp_dir().join(format!(
+                "wayback-rpki-backup-{}-{}.jsonl.gz",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)?
+                    .as_nanos()
+            ));
+            trie.export_jsonl(temp.to_str().unwrap())?;
             oneio::s3_env_check()?;
-            oneio::s3_upload(&bucket, &key, upload_source)?;
+            oneio::s3_upload(&bucket, &key, temp.to_str().unwrap())?;
+            let _ = std::fs::remove_file(&temp);
             Ok(())
         }
         Err(_) => {
-            std::fs::copy(upload_source, destination)?;
+            trie.export_jsonl(destination)?;
             Ok(())
         }
-    };
-    if let Some(temp) = temporary {
-        let _ = std::fs::remove_file(temp);
     }
-    result
 }
 
 /// Ensure a requested archive is present.
 ///
-/// For a missing `.rkyv`, a local sibling legacy archive is always preferred:
-/// `roas_trie.bin.gz`/`.bin` is converted before attempting network bootstrap.
+/// Bootstrap precedence for missing `.rkyv`:
+/// 1. Local sibling `.bin.gz`/`.bin` → auto-convert
+/// 2. Remote `roas_trie.jsonl.gz` → stream-import → dump rkyv
+/// 3. Remote `roas_trie.bin.gz` → download → auto-convert (legacy fallback)
 fn check_bootstrap_and_download(path: &str, bootstrap: bool) {
     const LEGACY_BOOTSTRAP_URL: &str = "https://spaces.bgpkit.org/broker/roas_trie.bin.gz";
 
@@ -542,6 +530,7 @@ fn check_bootstrap_and_download(path: &str, bootstrap: bool) {
     }
 
     if is_rkyv_path(path) {
+        // 1. Local sibling legacy archive
         if let Some(bin_path) = find_sibling_bin(path) {
             info!(
                 "requested {} not found; auto-converting local sibling {} before bootstrap",
@@ -557,19 +546,15 @@ fn check_bootstrap_and_download(path: &str, bootstrap: bool) {
     }
 
     if is_rkyv_path(path) {
-        info!(
-            "no local legacy archive found; attempting compressed rkyv bootstrap {}",
-            REMOTE_BOOTSTRAP_URL
-        );
-        if let Err(rkyv_error) = download_rkyv_transport(REMOTE_BOOTSTRAP_URL, path) {
-            // During the transition the v1 archive remains the durable remote
-            // bootstrap source. Download it beside the requested rkyv path, then
-            // reuse the normal conversion path to create the mmap-ready archive.
-            let legacy_path = format!("{}.bin.gz", path.strip_suffix(".rkyv").unwrap_or(path));
+        // 2. Remote JSONL transport (platform-agnostic, low RAM)
+        info!("attempting JSONL bootstrap {}", REMOTE_BOOTSTRAP_URL);
+        if let Err(jsonl_error) = bootstrap_from_jsonl(REMOTE_BOOTSTRAP_URL, path) {
+            // 3. Fall back to legacy bin.gz
             warn!(
-                "rkyv bootstrap {} failed: {}; falling back to legacy bootstrap {}",
-                REMOTE_BOOTSTRAP_URL, rkyv_error, LEGACY_BOOTSTRAP_URL
+                "JSONL bootstrap {} failed: {}; falling back to legacy bootstrap {}",
+                REMOTE_BOOTSTRAP_URL, jsonl_error, LEGACY_BOOTSTRAP_URL
             );
+            let legacy_path = format!("{}.bin.gz", path.strip_suffix(".rkyv").unwrap_or(path));
             if let Err(legacy_error) = oneio::download(LEGACY_BOOTSTRAP_URL, &legacy_path) {
                 error!(
                     "legacy bootstrap {} also failed: {}",
@@ -629,7 +614,8 @@ fn ensure_data_available(path: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Read;
+    use std::io::Write;
+    use wayback_rpki::RoaEntry;
 
     fn unique_path(suffix: &str) -> std::path::PathBuf {
         std::env::temp_dir().join(format!(
@@ -644,26 +630,60 @@ mod tests {
     }
 
     #[test]
-    fn rkyv_gzip_backup_is_transport_only() {
-        let source = unique_path(".rkyv");
-        let backup = unique_path(".rkyv.gz");
-        let payload = b"raw rkyv archive bytes: must remain mmap-ready locally";
-        std::fs::write(&source, payload).unwrap();
+    fn jsonl_round_trip_preserves_data() {
+        // Build a small trie via direct record insertion, export to JSONL.gz,
+        // re-import, and verify search results match.
+        let rkyv = unique_path(".rkyv");
+        let jsonl = unique_path(".jsonl.gz");
+        let rkyv2 = unique_path(".rkyv");
 
-        backup_archive(source.to_str().unwrap(), backup.to_str().unwrap()).unwrap();
-        assert!(backup.exists());
-        assert_ne!(std::fs::read(&backup).unwrap(), payload);
+        // Build a trie with known data via JSONL input
+        let jsonl_in = unique_path(".jsonl.gz");
+        {
+            let mut w =
+                std::io::BufWriter::new(oneio::get_writer(jsonl_in.to_str().unwrap()).unwrap());
+            let ts = chrono::NaiveDate::from_ymd_opt(2024, 1, 1)
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap()
+                .and_utc()
+                .timestamp();
+            for (p, m, o) in [("1.1.1.0/24", 24u8, 13335u32), ("8.8.8.0/24", 24, 15169)] {
+                let rec = serde_json::json!({"p": p, "m": m, "o": o, "r": [[ts, ts]]});
+                w.write_all(format!("{}\n", rec).as_bytes()).unwrap();
+            }
+            w.flush().unwrap();
+        }
 
-        let mut decoded = Vec::new();
-        oneio::get_reader(backup.to_str().unwrap())
-            .unwrap()
-            .read_to_end(&mut decoded)
-            .unwrap();
-        assert_eq!(decoded, payload);
-        assert_eq!(std::fs::read(&source).unwrap(), payload);
+        let mut builder = RoasTrieMut::from_jsonl(jsonl_in.to_str().unwrap()).unwrap();
+        builder.dump(rkyv.to_str().unwrap()).unwrap();
 
-        let _ = std::fs::remove_file(source);
-        let _ = std::fs::remove_file(backup);
+        let trie = RoasTrie::open(rkyv.to_str().unwrap()).unwrap();
+        trie.export_jsonl(jsonl.to_str().unwrap()).unwrap();
+
+        // Re-import the exported JSONL
+        let mut builder2 = RoasTrieMut::from_jsonl(jsonl.to_str().unwrap()).unwrap();
+        builder2.dump(rkyv2.to_str().unwrap()).unwrap();
+        let trie2 = RoasTrie::open(rkyv2.to_str().unwrap()).unwrap();
+
+        // Compare results
+        let prefix: IpNet = "1.1.1.0/24".parse().unwrap();
+        let orig = trie.search(Some(prefix), None, None, None, None, true);
+        let new = trie2.search(Some(prefix), None, None, None, None, true);
+        assert_eq!(orig.len(), 1);
+        assert_eq!(orig, new);
+        assert_eq!(orig[0].origin, 13335);
+
+        let prefix2: IpNet = "8.8.8.0/24".parse().unwrap();
+        let orig2 = trie.search(Some(prefix2), None, None, None, None, true);
+        let new2 = trie2.search(Some(prefix2), None, None, None, None, true);
+        assert_eq!(orig2, new2);
+        assert_eq!(orig2[0].origin, 15169);
+
+        let _ = std::fs::remove_file(rkyv);
+        let _ = std::fs::remove_file(jsonl);
+        let _ = std::fs::remove_file(rkyv2);
+        let _ = std::fs::remove_file(jsonl_in);
     }
 
     #[test]

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -490,7 +490,7 @@ fn bootstrap_from_jsonl(url: &str, rkyv_path: &str) -> anyhow::Result<()> {
 }
 
 /// Write a backup from the live `.rkyv` archive to a `.jsonl[.gz]` transport file.
-/// Streams zero-copy from the mmap'd archive — peak memory ~10 MB.
+/// Iterates the mmap'd archive and serializes one record at a time.
 fn backup_archive(source: &str, destination: &str) -> anyhow::Result<()> {
     let trie = RoasTrie::open(source)?;
     match oneio::s3_url_parse(destination) {
@@ -615,7 +615,6 @@ fn ensure_data_available(path: &str) {
 mod tests {
     use super::*;
     use std::io::Write;
-    use wayback_rpki::RoaEntry;
 
     fn unique_path(suffix: &str) -> std::path::PathBuf {
         std::env::temp_dir().join(format!(

--- a/src/roas_trie.rs
+++ b/src/roas_trie.rs
@@ -13,9 +13,9 @@ use tracing::{info, warn};
 /// On-disk format version. v2: rkyv archive of [`RoasTrieData`].
 pub const FORMAT_VERSION: u32 = 2;
 
-/// Default remote bootstrap archive URL. This is gzip-compressed for transport;
-/// the client streams it into a raw local `.rkyv` file for mmap serving.
-pub const REMOTE_BOOTSTRAP_URL: &str = "https://spaces.bgpkit.org/broker/roas_trie.rkyv.gz";
+/// Default remote bootstrap URL. Platform-agnostic JSONL.gz transport format;
+/// the client streams it through a builder and dumps a local `.rkyv` for mmap serving.
+pub const REMOTE_BOOTSTRAP_URL: &str = "https://spaces.bgpkit.org/broker/roas_trie.jsonl.gz";
 
 pub(crate) const KNOWN_GAPS_STR: [(&str, &str); 24] = [
     ("2018-12-28", "2019-01-02"),
@@ -163,7 +163,7 @@ pub struct RoasTrieData {
     pub trie: JointPrefixMap<IpNet, Vec<RoaRecord>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RoasLookupEntry {
     pub prefix: IpNet,
     pub origin: u32,
@@ -710,6 +710,144 @@ fn archived_lookup_entry(prefix: IpNet, r: &ArchivedRoaRecord) -> RoasLookupEntr
                 )
             })
             .collect(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JSONL platform-agnostic transport format
+// ---------------------------------------------------------------------------
+
+/// One JSONL line: a single (prefix, max_len, origin) ROA record with compressed
+/// date ranges. This is the on-the-wire format for bootstrap downloads and
+/// remote backups — platform-agnostic and streamable.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct JsonlRecord {
+    /// Prefix in CIDR notation, e.g. "1.1.1.0/24"
+    pub p: String,
+    /// ROA max length
+    pub m: u8,
+    /// Origin ASN
+    pub o: u32,
+    /// Compressed date ranges as (start_ts, end_ts) pairs
+    pub r: Vec<(i64, i64)>,
+}
+
+impl RoasTrieMut {
+    /// Stream-import a `.jsonl[.gz]` file into this builder. Each line is one
+    /// `JsonlRecord`. The builder grows incrementally — peak memory is just
+    /// the builder itself (~200 MB for the full production dataset).
+    pub fn import_jsonl(&mut self, path: &str) -> Result<()> {
+        info!("importing JSONL from {} ...", path);
+        let reader = oneio::get_reader(path)?;
+        let mut buf_reader = std::io::BufReader::new(reader);
+        let mut line = String::new();
+        let mut count: u64 = 0;
+
+        loop {
+            line.clear();
+            let n = std::io::BufRead::read_line(&mut buf_reader, &mut line)?;
+            if n == 0 {
+                break;
+            }
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let rec: JsonlRecord = serde_json::from_str(trimmed)
+                .map_err(|e| anyhow!("JSONL parse error at line {}: {}", count + 1, e))?;
+            let prefix: IpNet = rec
+                .p
+                .parse()
+                .map_err(|e| anyhow!("invalid prefix '{}' at line {}: {}", rec.p, count + 1, e))?;
+
+            // Track latest date before moving rec.r
+            for &(start, end) in &rec.r {
+                if end > self.latest_date {
+                    self.latest_date = end;
+                }
+                if start > self.latest_date {
+                    self.latest_date = start;
+                }
+            }
+
+            let record = RoaRecordMut {
+                max_len: rec.m,
+                origin: rec.o,
+                dates: HashSet::new(),
+                ranges: rec.r,
+            };
+
+            // Merge with existing records for the same prefix + (max_len, origin)
+            match self.trie.get_mut(&prefix) {
+                Some(recs) => {
+                    if let Some(existing) = recs
+                        .iter_mut()
+                        .find(|r| r.max_len == record.max_len && r.origin == record.origin)
+                    {
+                        existing.ranges.extend(record.ranges.iter().copied());
+                        existing.full_compress();
+                    } else {
+                        recs.push(record);
+                    }
+                }
+                None => {
+                    self.trie.insert(prefix, vec![record]);
+                }
+            }
+
+            count += 1;
+            if count % 200_000 == 0 {
+                info!("imported {} records...", count);
+            }
+        }
+
+        info!("imported {} records from JSONL", count);
+        Ok(())
+    }
+
+    /// Create a fresh builder from a JSONL file.
+    pub fn from_jsonl(path: &str) -> Result<Self> {
+        let mut builder = Self::new();
+        builder.import_jsonl(path)?;
+        Ok(builder)
+    }
+}
+
+impl RoasTrie {
+    /// Stream-export the archive to a `.jsonl[.gz]` file. Reads the mmap'd
+    /// archive zero-copy — peak memory is just the I/O buffer (~10 MB).
+    pub fn export_jsonl(&self, path: &str) -> Result<()> {
+        info!("exporting JSONL to {} ...", path);
+        let mut writer: Box<dyn std::io::Write> =
+            Box::new(std::io::BufWriter::new(oneio::get_writer(path)?));
+        let data = self.data();
+        let mut count: u64 = 0;
+
+        for (prefix, records) in data.trie.iter() {
+            for r in records.iter() {
+                let ranges: Vec<(i64, i64)> = r
+                    .dates
+                    .iter()
+                    .map(|range| (range.0.to_native(), range.1.to_native()))
+                    .collect();
+                let rec = JsonlRecord {
+                    p: prefix.to_string(),
+                    m: r.max_len,
+                    o: r.origin.to_native(),
+                    r: ranges,
+                };
+                serde_json::to_writer(&mut writer, &rec)?;
+                writer.write_all(b"\n")?;
+            }
+            count += 1;
+            if count % 200_000 == 0 {
+                info!("exported {} prefixes...", count);
+            }
+        }
+
+        writer.flush()?;
+        info!("exported {} prefixes to JSONL", count);
+        Ok(())
     }
 }
 

--- a/src/roas_trie.rs
+++ b/src/roas_trie.rs
@@ -741,6 +741,7 @@ impl RoasTrieMut {
         let reader = oneio::get_reader(path)?;
         let mut buf_reader = std::io::BufReader::new(reader);
         let mut line = String::new();
+        let mut line_no: u64 = 0;
         let mut count: u64 = 0;
 
         loop {
@@ -749,24 +750,29 @@ impl RoasTrieMut {
             if n == 0 {
                 break;
             }
+            line_no += 1;
             let trimmed = line.trim();
             if trimmed.is_empty() {
                 continue;
             }
             let rec: JsonlRecord = serde_json::from_str(trimmed)
-                .map_err(|e| anyhow!("JSONL parse error at line {}: {}", count + 1, e))?;
+                .map_err(|e| anyhow!("JSONL parse error at line {}: {}", line_no, e))?;
             let prefix: IpNet = rec
                 .p
                 .parse()
-                .map_err(|e| anyhow!("invalid prefix '{}' at line {}: {}", rec.p, count + 1, e))?;
+                .map_err(|e| anyhow!("invalid prefix '{}' at line {}: {}", rec.p, line_no, e))?;
 
-            // Track latest date before moving rec.r
             for &(start, end) in &rec.r {
+                if start > end {
+                    return Err(anyhow!(
+                        "invalid date range at line {}: start {} is after end {}",
+                        line_no,
+                        start,
+                        end
+                    ));
+                }
                 if end > self.latest_date {
                     self.latest_date = end;
-                }
-                if start > self.latest_date {
-                    self.latest_date = start;
                 }
             }
 
@@ -814,8 +820,9 @@ impl RoasTrieMut {
 }
 
 impl RoasTrie {
-    /// Stream-export the archive to a `.jsonl[.gz]` file. Reads the mmap'd
-    /// archive zero-copy — peak memory is just the I/O buffer (~10 MB).
+    /// Stream-export the archive to a `.jsonl[.gz]` file. Reads record data
+    /// directly from the mmap'd archive and keeps only one serialized record
+    /// in memory at a time.
     pub fn export_jsonl(&self, path: &str) -> Result<()> {
         info!("exporting JSONL to {} ...", path);
         let mut writer: Box<dyn std::io::Write> =
@@ -949,5 +956,42 @@ mod tests {
         let prefix: IpNet = "1.1.1.0/24".parse().unwrap();
         let results = trie.lookup_prefix(&prefix);
         assert_eq!(results.len(), 3);
+    }
+
+    #[test]
+    fn import_jsonl_reports_physical_line_number() {
+        let path = std::env::temp_dir().join(format!(
+            "wayback-rpki-invalid-jsonl-{}-{}.jsonl",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::write(&path, "\n{not valid json}\n").unwrap();
+
+        let err = RoasTrieMut::from_jsonl(path.to_str().unwrap())
+            .err()
+            .unwrap()
+            .to_string();
+        assert!(err.contains("line 2"), "unexpected error: {err}");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn import_jsonl_rejects_inverted_date_range() {
+        let path = std::env::temp_dir().join(format!(
+            "wayback-rpki-invalid-range-{}-{}.jsonl",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::write(&path, r#"{"p":"1.1.1.0/24","m":24,"o":13335,"r":[[2,1]]}"#).unwrap();
+
+        let err = RoasTrieMut::from_jsonl(path.to_str().unwrap())
+            .err()
+            .unwrap()
+            .to_string();
+        assert!(
+            err.contains("invalid date range at line 1"),
+            "unexpected error: {err}"
+        );
+        let _ = std::fs::remove_file(path);
     }
 }


### PR DESCRIPTION
## Summary

Replace the platform-specific `.rkyv.gz` transport format with platform-agnostic `.jsonl.gz`, targeting Railway deployment where RAM is constrained.

## Problem

rkyv archives embed platform-specific `usize` offsets and alignment — an archive written on `x86_64` can't be safely mmap'd on `aarch64`. The previous `.rkyv.gz` transport format was not portable.

## Changes

### JSONL transport format
- **Schema:** one line per `(prefix, max_len, origin)` ROA record with compressed date ranges
  ```jsonl
  {"p":"1.1.1.0/24","m":24,"o":13335,"r":[[1522886400,1743638400]]}
  ```
- **`RoasTrieMut::import_jsonl`**: streams records one at a time into the builder — peak RAM ~200 MB (vs ~1 GB for v1 conversion)
- **`RoasTrie::export_jsonl`**: streams zero-copy from the mmap archive — peak RAM ~10 MB

### Bootstrap precedence (updated)
1. Local sibling `.bin.gz`/`.bin` → convert
2. Remote `roas_trie.jsonl.gz` → stream-import → dump rkyv (**preferred**, ~200 MB peak)
3. Remote `roas_trie.bin.gz` → download → convert (legacy fallback)

### Backup
- Replaced `.rkyv.gz` gzip transport with `.jsonl.gz` stream export from the live mmap archive
- S3 uploads write to a temp file, then upload

### Removed
- `download_rkyv_transport()`, `create_rkyv_transport_gzip()` — all rkyv.gz transport code
- `REMOTE_BOOTSTRAP_URL` changed from `.rkyv.gz` to `.jsonl.gz`

## RAM impact (Railway-targeted)

| Phase | Before (rkyv.gz / bin.gz) | After (jsonl.gz) |
|---|---|---|
| Bootstrap peak | ~1 GB (full v1 trie + builder) | ~200 MB (builder only) |
| Backup peak | ~10 MB (already streaming) | ~10 MB (same) |
| Steady-state serving | ~5 MB (mmap) | ~5 MB (unchanged) |

## Verification
- 16 tests pass (14 lib + 2 binary, including new JSONL round-trip test)
- `cargo clippy --all-features -- -D warnings` clean
- Release build passes
- JSONL round-trip verified: build → export → re-import → search results identical
