### PR TITLE
perf: use jemalloc to cut RSS from 1.28GB to 569MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
 * Platform-agnostic JSONL.gz transport: bootstrap and backups now stream a portable
   `.jsonl.gz` format instead of platform-specific `.rkyv.gz`, cutting bootstrap peak RAM from
   ~1 GB to ~200 MB (#13)
+* jemalloc global allocator: RSS drops from ~1.28 GB to ~569 MB steady-state by returning
+  freed pages to the OS after bootstrap/update spikes — fits Railway's 1 GB plan (#14)
 * Smooth v1 → v2 transition: legacy `.bin`/`.bin.gz` archives (local sibling or remote
   bootstrap) are auto-converted on first run — no manual migration or prompts (#12)
 
@@ -35,6 +37,8 @@ All notable changes to this project will be documented in this file.
   archive (#13)
 * Archive updates write to a temp file and atomically rename for safe hot-reload during
   background updates (#12)
+* jemalloc global allocator (`tikv_jemallocator`) returns freed pages to the OS after
+  bootstrap/update, cutting steady-state RSS by 55% (#14)
 
 ### Bug Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2217,6 +2217,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2596,6 +2616,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tabled",
+ "tikv-jemallocator",
  "tokio",
  "tower-http",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ rust-version = "1.81"
 name = "wayback-rpki"
 path = "src/bin/main.rs"
 
-
 [dependencies]
 
 anyhow = "1"
+tikv-jemallocator = "0.6"
 oneio = { version = "0.24", default-features = false, features = ["https", "xz", "gz", "s3"] }
 chrono = "0.4.38"
 dotenvy = "0.15"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,3 +1,8 @@
+use tikv_jemallocator::Jemalloc;
+
+#[global_allocator]
+static ALLOC: Jemalloc = Jemalloc;
+
 use chrono::NaiveDate;
 use clap::{Parser, Subcommand};
 use indicatif::{ProgressBar, ProgressStyle};


### PR DESCRIPTION
## Summary

Replace glibc's default allocator with jemalloc via `tikv_jemallocator` global allocator. This is critical for Railway deployment where RAM is constrained.

## Problem

glibc's allocator holds freed pages after the bootstrap/update spike (~1.2 GB high-water mark) for the container's entire lifetime. Steady-state RSS was **1.28 GB** flat — never shrinking — because glibc never returns memory to the OS.

## Result

| Metric | Before (glibc) | After (jemalloc) |
|---|---|---|
| Steady-state RSS | 1.28 GB | **569 MB** |
| Reduction | — | 55% |
| Under query load | No growth | No growth |
| Stability | Flat | Flat |

jemalloc aggressively purges freed pages, so after the bootstrap import + rkyv dump completes, RSS drops to the actual live working set (~569 MB = mmap archive + serving overhead).

Fits comfortably within Railway's 1 GB plan.

## Changes
- Added `tikv-jemallocator = "0.6"` dependency
- `#[global_allocator] static ALLOC: Jemalloc = Jemalloc;` in `main.rs`
