### PR TITLE
fix: check_date month boundary dropped Q4 of every non-boundary year

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 
 pub mod api;
 pub mod legacy;
-pub mod pg_ingest;
 mod roas_trie;
 
 use anyhow::{anyhow, Result};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod api;
 pub mod legacy;
+pub mod pg_ingest;
 mod roas_trie;
 
 use anyhow::{anyhow, Result};
@@ -81,19 +82,32 @@ fn check_date(
     check_month: bool,
     check_day: bool,
 ) -> bool {
+    // Boundary months only apply to the boundary year itself: comparing
+    // `month` across ALL years silently drops whole months (e.g. until
+    // 2026-09-03 excluded Oct-Dec of every earlier year).
     let from_match = match from {
         Some(from_date) => {
-            date.year() >= from_date.year()
-                && (check_month && date.month() >= from_date.month() || !check_month)
-                && (check_day && date >= from_date || !check_day)
+            if !check_month {
+                date.year() >= from_date.year()
+            } else if !check_day {
+                date.year() > from_date.year()
+                    || (date.year() == from_date.year() && date.month() >= from_date.month())
+            } else {
+                date >= from_date
+            }
         }
         None => true,
     };
     let until_match = match until {
         Some(until_date) => {
-            date.year() <= until_date.year()
-                && (check_month && date.month() <= until_date.month() || !check_month)
-                && (check_day && date <= until_date || !check_day)
+            if !check_month {
+                date.year() <= until_date.year()
+            } else if !check_day {
+                date.year() < until_date.year()
+                    || (date.year() == until_date.year() && date.month() <= until_date.month())
+            } else {
+                date <= until_date
+            }
         }
         None => true,
     };
@@ -288,5 +302,35 @@ mod tests {
                 dbg!(entry);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod check_date_tests {
+    use super::*;
+    use chrono::NaiveDate;
+
+    fn d(s: &str) -> NaiveDate {
+        NaiveDate::parse_from_str(s, "%Y-%m-%d").unwrap()
+    }
+
+    #[test]
+    fn until_boundary_month_excludes_only_boundary_year() {
+        // Regression: until 2026-09-03 must NOT drop Oct-Dec of earlier years.
+        let until = d("2026-09-03");
+        assert!(check_date(d("2025-10-24"), None, Some(until), true, true));
+        assert!(check_date(d("2020-12-31"), None, Some(until), true, true));
+        assert!(!check_date(d("2026-10-01"), None, Some(until), true, true));
+        // month-grain (used for month listing)
+        assert!(check_date(d("2025-12-01"), None, Some(until), true, false));
+        assert!(!check_date(d("2026-10-01"), None, Some(until), true, false));
+    }
+
+    #[test]
+    fn from_boundary_month_excludes_only_boundary_year() {
+        let from = d("2015-03-10");
+        assert!(check_date(d("2016-01-05"), Some(from), None, true, true));
+        assert!(check_date(d("2016-01-01"), Some(from), None, true, false));
+        assert!(!check_date(d("2015-02-28"), Some(from), None, true, true));
     }
 }


### PR DESCRIPTION
## Root cause

`check_date` applied the boundary month across **all** years: with `until` in Jan-Sep, the month-grain filter `month <= until.month()` silently excluded October-December of every earlier year (and the `from` side had the mirror-image bug). The skip is silent: no error, no warning, the affected days simply never enter the crawl result.

Daily `update` runs are unaffected in practice because their windows are 1-2 days, but any multi-year `crawl_tal_after` call (`rebuild --from/--until`, replays, repairs) loses whole quarters. Found while diffing a multi-year backfill against the production archive: months 10-12 had zero ingested file-days while the archive contains them.

## Fix

Month and day comparisons now only apply within the boundary year; earlier/later years pass on the year comparison alone. Both boundaries covered at day and month grain.

## Validation

- Two regression tests: `until 2026-09-03` must not exclude 2025-10-24 / 2020-12-31; `from 2015-03-10` must not exclude 2016-01-05.
- `cargo test`, `cargo clippy --all-targets -D warnings`, `cargo fmt --check` all green.